### PR TITLE
[FRONT-187] Use detectFields from streamr-client

### DIFF
--- a/app/src/userpages/components/StreamPage/Edit/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/ConfigureView/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Fragment, useMemo, useState, useCallback } from 'react'
-import { useSelector } from 'react-redux'
 import { arrayMove } from 'react-sortable-hoc'
 import uuid from 'uuid'
 import styled from 'styled-components'
@@ -12,7 +11,7 @@ import type { Stream } from '$shared/flowtype/stream-types'
 import FieldList from '$shared/components/FieldList'
 import FieldItem from '$shared/components/FieldList/FieldItem'
 import Select from '$ui/Select'
-import { selectFieldsAutodetectFetching, fieldTypes } from '$userpages/modules/userPageStreams/selectors'
+import { fieldTypes } from '$userpages/modules/userPageStreams/selectors'
 import Text from '$ui/Text'
 import SplitControl from '$userpages/components/SplitControl'
 import Notification from '$shared/utils/Notification'
@@ -54,7 +53,7 @@ const ConfigureView = ({ stream, disabled, updateStream }: Props) => {
         label: fieldTypes[t],
     })), [])
     const [isAddingField, setIsAddingField] = useState(false)
-    const fieldsAutodetectFetching = useSelector(selectFieldsAutodetectFetching)
+    const [isAutoDetecting, setIsAutodetecting] = useState(false)
     const isMounted = useIsMounted()
     const client = useClient()
 
@@ -126,6 +125,7 @@ const ConfigureView = ({ stream, disabled, updateStream }: Props) => {
     const autodetectFields = useCallback(async () => {
         if (streamId) {
             try {
+                setIsAutodetecting(true)
                 const streamObj = await client.getStream(streamId)
                 await streamObj.detectFields()
 
@@ -152,11 +152,13 @@ const ConfigureView = ({ stream, disabled, updateStream }: Props) => {
                     title: err.message,
                     icon: NotificationIcon.ERROR,
                 })
+            } finally {
+                setIsAutodetecting(false)
             }
         }
     }, [streamId, isMounted, client, updateStream])
 
-    const isDisabled = !!(disabled || fieldsAutodetectFetching)
+    const isDisabled = !!(disabled || isAutoDetecting)
 
     return (
         <div>
@@ -215,10 +217,10 @@ const ConfigureView = ({ stream, disabled, updateStream }: Props) => {
                         outline
                         onClick={autodetectFields}
                         disabled={isDisabled}
-                        waiting={fieldsAutodetectFetching}
+                        waiting={isAutoDetecting}
                     >
-                        {!fieldsAutodetectFetching && 'Autodetect fields'}
-                        {!!fieldsAutodetectFetching && 'Waiting...'}
+                        {!isAutoDetecting && 'Autodetect fields'}
+                        {!!isAutoDetecting && 'Waiting...'}
                     </Button>
                 </Buttons>
             }

--- a/app/src/userpages/components/StreamPage/Edit/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/ConfigureView/index.jsx
@@ -127,11 +127,16 @@ const ConfigureView = ({ stream, disabled, updateStream }: Props) => {
         if (streamId) {
             try {
                 const streamObj = await client.getStream(streamId)
-                if (!isMounted()) { return }
+                await streamObj.detectFields()
 
-                streamObj.detectFields()
+                if (!isMounted()) { return }
+                const newFields = streamObj.config.fields.map((f) => ({
+                    ...f,
+                    id: uuid(),
+                }))
+
                 if (typeof updateStream === 'function') {
-                    updateStream('config.fields', streamObj.config.fields)
+                    updateStream('config.fields', newFields)
                 }
 
                 Notification.push({

--- a/app/src/userpages/flowtype/states/stream-state.js
+++ b/app/src/userpages/flowtype/states/stream-state.js
@@ -12,7 +12,6 @@ export type UserPageStreamsState = {
     updating: boolean,
     error?: ?ErrorInUi,
     savingStreamFields: boolean,
-    autodetectFetching: boolean,
     pageSize: number,
     hasMoreSearchResults: ?boolean,
 }

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -4,7 +4,7 @@ import set from 'lodash/set'
 
 import uuid from 'uuid'
 import type { ErrorInUi } from '$shared/flowtype/common-types'
-import type { Stream, StreamId, StreamIdList, StreamFieldList } from '$shared/flowtype/stream-types'
+import type { Stream, StreamId, StreamIdList } from '$shared/flowtype/stream-types'
 import type { Filter } from '$userpages/flowtype/common-types'
 import type { ResourceId } from '$userpages/flowtype/permission-types'
 
@@ -41,24 +41,6 @@ export const DELETE_STREAM_SUCCESS = 'userpages/streams/DELETE_STREAM_SUCCESS'
 export const DELETE_STREAM_FAILURE = 'userpages/streams/DELETE_STREAM_FAILURE'
 
 export const OPEN_STREAM = 'userpages/streams/OPEN_STREAM'
-
-export const STREAM_FIELD_AUTODETECT_REQUEST = 'userpages/streams/STREAM_FIELD_AUTODETECT_REQUEST'
-export const STREAM_FIELD_AUTODETECT_SUCCESS = 'userpages/streams/STREAM_FIELD_AUTODETECT_SUCCESS'
-export const STREAM_FIELD_AUTODETECT_FAILURE = 'userpages/streams/STREAM_FIELD_AUTODETECT_FAILURE'
-
-const getStreamFieldAutodetectRequest = () => ({
-    type: STREAM_FIELD_AUTODETECT_REQUEST,
-})
-
-const getStreamFieldAutodetectSuccess = (fields: StreamFieldList) => ({
-    type: STREAM_FIELD_AUTODETECT_SUCCESS,
-    fields,
-})
-
-const getStreamFieldAutodetectFailure = (error: ErrorInUi) => ({
-    type: STREAM_FIELD_AUTODETECT_FAILURE,
-    error,
-})
 
 const getStreamRequest = () => ({
     type: GET_STREAM_REQUEST,
@@ -301,28 +283,6 @@ export const updateEditStreamField = (field: string, data: any) => (dispatch: Fu
     set(stream, field, data)
 
     handleEntities(streamSchema, dispatch)(stream)
-}
-
-export const streamFieldsAutodetect = (id: StreamId) => (dispatch: Function) => {
-    dispatch(getStreamFieldAutodetectRequest())
-    return services.autodetectStreamfields(id)
-        .then((data) => ({
-            id,
-            config: {
-                fields: data.config.fields,
-            },
-        }))
-        .then(({ config: { fields } }) => {
-            if (fields) {
-                dispatch(updateEditStreamField('config.fields', fields))
-                dispatch(getStreamFieldAutodetectSuccess(fields))
-            }
-        }, (err) => {
-            if (err) {
-                dispatch(getStreamFieldAutodetectFailure(err))
-                throw err
-            }
-        })
 }
 
 export const openStream = (id: ?StreamId) => ({

--- a/app/src/userpages/modules/userPageStreams/reducer.js
+++ b/app/src/userpages/modules/userPageStreams/reducer.js
@@ -22,9 +22,6 @@ import {
     DELETE_STREAM_SUCCESS,
     DELETE_STREAM_FAILURE,
     OPEN_STREAM,
-    STREAM_FIELD_AUTODETECT_REQUEST,
-    STREAM_FIELD_AUTODETECT_SUCCESS,
-    STREAM_FIELD_AUTODETECT_FAILURE,
 } from './actions'
 
 const initialState = {
@@ -144,30 +141,6 @@ export default function (state: UserPageStreamsState = initialState, action: Str
                     id: action.id,
                 },
             }
-
-        case STREAM_FIELD_AUTODETECT_REQUEST: {
-            return {
-                ...state,
-                autodetectFetching: true,
-            }
-        }
-
-        case STREAM_FIELD_AUTODETECT_SUCCESS: {
-            const newState = {
-                ...state,
-                autodetectFetching: false,
-            }
-
-            return newState
-        }
-
-        case STREAM_FIELD_AUTODETECT_FAILURE: {
-            return {
-                ...state,
-                autodetectFetching: false,
-                streamFieldAutodetectError: action.error,
-            }
-        }
 
         default:
             return state

--- a/app/src/userpages/modules/userPageStreams/reducer.js
+++ b/app/src/userpages/modules/userPageStreams/reducer.js
@@ -34,7 +34,6 @@ const initialState = {
     updating: false,
     deleting: false,
     error: null,
-    autodetectFetching: false,
     streamFieldAutodetectError: null,
     pageSize: streamListPageSize,
     hasMoreSearchResults: null,

--- a/app/src/userpages/modules/userPageStreams/selectors.js
+++ b/app/src/userpages/modules/userPageStreams/selectors.js
@@ -54,11 +54,6 @@ export const selectUpdating: (StoreState) => boolean = createSelector(
     (subState: UserPageStreamsState): boolean => subState.updating,
 )
 
-export const selectFieldsAutodetectFetching: (StoreState) => boolean = createSelector(
-    selectUserPageStreamsState,
-    (subState: UserPageStreamsState): boolean => subState.autodetectFetching,
-)
-
 export const selectPageSize: (StoreState) => number = createSelector(
     selectUserPageStreamsState,
     (subState: UserPageStreamsState): number => subState.pageSize,

--- a/app/src/userpages/modules/userPageStreams/services.js
+++ b/app/src/userpages/modules/userPageStreams/services.js
@@ -50,9 +50,3 @@ export const getStreams = (params: any, pageSize: number, offset: number): ApiRe
         streams: streams.splice(0, pageSize),
         hasMoreResults: streams.length > 0,
     }))
-
-export const autodetectStreamfields = (streamId: StreamId): ApiResult<Stream> => get({
-    url: routes.api.streams.detectFields({
-        streamId,
-    }),
-})

--- a/app/src/userpages/tests/modules/userPagesStreams/reducer.test.js
+++ b/app/src/userpages/tests/modules/userPagesStreams/reducer.test.js
@@ -11,7 +11,6 @@ const initialState = {
     updating: false,
     deleting: false,
     error: null,
-    autodetectFetching: false,
     streamFieldAutodetectError: null,
     pageSize: 20,
     hasMoreSearchResults: null,


### PR DESCRIPTION
Removes unsupported API calls for stream field detection and uses the feature from `streamr-client`.