### PR TITLE
Fix JSON quotes

### DIFF
--- a/app/src/docs/content/streams/usingStreamsViaApi.mdx
+++ b/app/src/docs/content/streams/usingStreamsViaApi.mdx
@@ -9,7 +9,7 @@ While the Core UI can do just about everything you'd want to do with streams, so
 Events in streams can be queried via HTTP. Example using `curl`:
 
 <CodeSnippet language="bash">
-    {`curl -i -X POST -H "Authorization: Bearer MY-SESSION-TOKEN" -d "{\"foo\":\"hello\",\"bar\":24.5}" https://streamr.network/api/v1/streams/MY-STREAM-ID/data`}
+    {`curl -i -X POST -H "Authorization: Bearer MY-SESSION-TOKEN" -d '{"foo":"hello","bar":24.5}' https://streamr.network/api/v1/streams/MY-STREAM-ID/data`}
 </CodeSnippet>
 
 The following endpoint would return the 5 most recent messages in a stream (or to be more precise, the default partition 0 of a stream):


### PR DESCRIPTION
Replace double quotes by single quotes to avoid the error on command execution: `{"error":"Invalid JSON in stream: {foo:hello,bar:24.5}. Error while parsing was: SyntaxError: Unexpected token f in JSON at position 1"}%`

Wrong: `"{"foo":"hello","bar":24.5}"`
Correct: `'{"foo":"hello","bar":24.5}'`

Webpage: https://streamr.network/docs/api/using-streams-via-api

<img width="768" alt="Screenshot 2021-06-12 at 08 54 32" src="https://user-images.githubusercontent.com/84582633/121767957-d327de80-cb5b-11eb-9bd7-fdd41e6257ac.png">
