### PR TITLE
[FRONT-379] Dataunion management to use subgraph

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -71,6 +71,7 @@ jobs:
           DATA_UNION_SIDECHAIN_PROVIDER: https://rpc.xdaichain.com/
           DATA_UNION_SIDECHAIN_ID: 100
           DATAUNION_VERSION: 2
+          THE_GRAPH_API_URL: https://api.thegraph.com
         run: npm run build --if-present
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/app/README.md
+++ b/app/README.md
@@ -62,6 +62,7 @@ To be able to use the Marketplace, you'll need to configure these variables into
 | DATA_UNION_OPERATOR_ADDRESS                       |                                                                      |
 | DATA_UNION_BLOCK_FREEZE_PERIOD_SECONDS            |                                                                      |
 | DATA_UNION_PUBLISH_MEMBER_LIMIT                   | Number of members required for a data union product before publish   |
+| THE_GRAPH_API_URL                                 | Address of the environment's The Graph API                           |
 
 Development values (set the values in your `.env`):
 
@@ -78,13 +79,14 @@ Development values (set the values in your `.env`):
 | WEB3_REQUIRED_NETWORK_ID                          | 8995                                         |                                 |
 | WEB3_PUBLIC_HTTP_PROVIDER                         | http://localhost:8545                        | Private network                 |
 | WEB3_PUBLIC_WS_PROVIDER                           | ws://localhost:8545                          |                                 |
-| WEB3_TRANSACTION_CONFIRMATION_BLOCKS              | 1                                            | Parity confirms tx immediately |
+| WEB3_TRANSACTION_CONFIRMATION_BLOCKS              | 1                                            | Parity confirms tx immediately  |
 | BUNDLE_ANALYSIS                                   | 1                                            | PLATFORM_ORIGIN_URL/report.html |
 | STREAMR_ENGINE_NODE_ADDRESSES                     | 0xFCAd0B19bB29D4674531d6f115237E16AfCE377c   |                                 |
 | UNISWAP_ADAPTOR_CONTRACT_ADDRESS                  | 0xe4ea76e830a659282368ca2e7e4d18c4ae52d8b3   |                                 |
 | DATA_UNION_OPERATOR_ADDRESS                       | 0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1   |                                 |
 | DATA_UNION_BLOCK_FREEZE_PERIOD_SECONDS            | 1                                            |                                 |
 | DATA_UNION_PUBLISH_MEMBER_LIMIT                   | 1                                            |                                 |
+| THE_GRAPH_API_URL                                 | `http://localhost:8000`                      |                                 |
 
 Optional config values:
 

--- a/app/src/marketplace/containers/ProductPage/DataUnionStats.jsx
+++ b/app/src/marketplace/containers/ProductPage/DataUnionStats.jsx
@@ -104,7 +104,7 @@ const UnstyledDataUnionStats = ({
                                 )}
                                 {dataUnion && dataUnion.version && dataUnion.version === 2 && (
                                     <MembersGraphV2
-                                        memberCount={memberCount.total}
+                                        memberCount={memberCount.active}
                                         shownDays={days}
                                         dataUnionAddress={dataUnion.id}
                                     />

--- a/app/src/marketplace/containers/ProductPage/MembersGraphV2.jsx
+++ b/app/src/marketplace/containers/ProductPage/MembersGraphV2.jsx
@@ -56,16 +56,32 @@ const MembersGraphV2 = ({ dataUnionAddress, memberCount, shownDays = 7 }: Props)
                 y: val.memberCountAtStart,
             })
             // Add a superficial datapoint to form a staircase graph
+            if ((val.endDate * 1000) <= Date.now()) {
+                data.push({
+                    x: (val.endDate * 1000) - 1,
+                    y: val.memberCountAtStart + val.memberCountChange,
+                })
+            }
+        }
+
+        // Make sure we fill the whole date range (end)
+        if (data.length === 0) {
             data.push({
-                x: (val.endDate * 1000) - 1,
-                y: val.memberCountAtStart + val.memberCountChange,
+                x: Date.now(),
+                y: memberCount,
+            })
+        } else {
+            const lastMemberCount = data[data.length - 1].y
+            data.push({
+                x: Date.now(),
+                y: lastMemberCount,
             })
         }
 
         if (data.length > 0) {
             const firstMemberCount = data[0].y
 
-            // Make sure we fill the whole date range
+            // Make sure we fill the whole date range (start)
             data.unshift({
                 x: startDate,
                 y: firstMemberCount,

--- a/app/src/marketplace/containers/ProductPage/MembersGraphV2.jsx
+++ b/app/src/marketplace/containers/ProductPage/MembersGraphV2.jsx
@@ -1,11 +1,11 @@
 // @flow
 
-import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react'
+import React, { useEffect, useState, useMemo, useCallback } from 'react'
 
 import useIsMounted from '$shared/hooks/useIsMounted'
 import ClientProvider from '$shared/components/StreamrClientProvider'
 import TimeSeriesGraph from '$shared/components/TimeSeriesGraph'
-import { getJoinsAndParts } from '$mp/modules/dataUnion/services'
+import { getMemberStatistics } from '$mp/modules/dataUnion/services'
 
 type Props = {
     dataUnionAddress: string,
@@ -17,10 +17,8 @@ const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
 
 const MembersGraphV2 = ({ dataUnionAddress, memberCount, shownDays = 7 }: Props) => {
     const isMounted = useIsMounted()
-    const [memberCountUpdatedAt, setMemberCountUpdatedAt] = useState(Date.now())
     const [memberData, setMemberData] = useState([])
     const [graphData, setGraphData] = useState([])
-    const generator = useRef(null)
 
     const startDate = useMemo(() => (
         Date.now() - (shownDays * MILLISECONDS_IN_DAY)
@@ -32,27 +30,11 @@ const MembersGraphV2 = ({ dataUnionAddress, memberCount, shownDays = 7 }: Props)
     }, [])
 
     useEffect(() => {
-        setMemberCountUpdatedAt(Date.now())
-    }, [memberCount])
-
-    useEffect(() => {
         const loadData = async () => {
             try {
-                if (generator.current != null) {
-                    generator.current.return('Canceled')
-                    generator.current = null
-                    reset()
-                }
-                generator.current = getJoinsAndParts(dataUnionAddress, startDate)
-
-                // eslint-disable-next-line no-restricted-syntax
-                for await (const event of generator.current) {
-                    if (isMounted()) {
-                        setMemberData((prev) => [
-                            ...prev,
-                            event,
-                        ])
-                    }
+                const statistics = await getMemberStatistics(dataUnionAddress, startDate)
+                if (isMounted()) {
+                    setMemberData(statistics)
                 }
             } catch (e) {
                 console.warn(e)
@@ -64,52 +46,34 @@ const MembersGraphV2 = ({ dataUnionAddress, memberCount, shownDays = 7 }: Props)
         }
     }, [dataUnionAddress, startDate, reset, isMounted])
 
-    useEffect(() => () => {
-        // Cancel generator on unmount
-        if (generator.current != null) {
-            generator.current.return('Canceled')
-            generator.current = null
-        }
-    }, [])
-
     useEffect(() => {
-        memberData.sort((a, b) => b.timestamp - a.timestamp)
+        const data = []
 
-        // Only thing we know at the beginning is total member count
-        // at given timestamp.
-        const initialData = [{
-            x: memberCountUpdatedAt,
-            y: memberCount,
-        }]
-
-        // Because we cannot read every event from blockchain, we have to
-        // work backwards from the initial state and calculate graph points
-        // using the member count diff.
-        const data = memberData.reduce((acc, element) => {
-            const latestValue = acc[acc.length - 1]
-            // Add a superficial datapoint with "old" count
-            // to happen 1ms before actual one to form a
-            // "staircase" graph
-            acc.push({
-                x: element.timestamp + 1,
-                y: latestValue.y,
+        // eslint-disable-next-line no-restricted-syntax
+        for (const val of memberData) {
+            data.push({
+                x: val.startDate * 1000,
+                y: val.memberCountAtStart,
             })
-            acc.push({
-                x: element.timestamp,
-                y: latestValue.y - element.diff,
+            // Add a superficial datapoint to form a staircase graph
+            data.push({
+                x: (val.endDate * 1000) - 1,
+                y: val.memberCountAtStart + val.memberCountChange,
             })
-            return acc
-        }, initialData)
+        }
 
-        const latestMemberCount = data[data.length - 1].y
+        if (data.length > 0) {
+            const firstMemberCount = data[0].y
 
-        // Make sure we fill the whole date range
-        data.push({
-            x: startDate,
-            y: latestMemberCount,
-        })
+            // Make sure we fill the whole date range
+            data.unshift({
+                x: startDate,
+                y: firstMemberCount,
+            })
+        }
+
         setGraphData(data)
-    }, [memberData, memberCount, memberCountUpdatedAt, startDate])
+    }, [memberData, memberCount, startDate])
 
     return (
         <TimeSeriesGraph

--- a/app/src/marketplace/flowtype/global-types.js
+++ b/app/src/marketplace/flowtype/global-types.js
@@ -9,6 +9,7 @@ declare class process {
         STREAMR_URL: string,
         STREAMR_WS_URL: string,
         GOOGLE_ANALYTICS_ID: string,
+        THE_GRAPH_API_URL: string,
         [key: string]: ?string
     }
 }

--- a/app/src/marketplace/modules/dataUnion/hooks/useDataUnionMembers.jsx
+++ b/app/src/marketplace/modules/dataUnion/hooks/useDataUnionMembers.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback, useState, useContext, useRef, useEffect } 
 
 import useIsMounted from '$shared/hooks/useIsMounted'
 import { useThrottled } from '$shared/hooks/wrapCallback'
-import { getMemberStatuses, removeMembers, searchDataUnionMembers } from '../services'
+import { getMemberStatuses, removeMembers, searchDataUnionMembers, getSelectedMemberStatuses } from '../services'
 
 const DataUnionMembersContext = React.createContext({})
 const VISIBLE_MEMBERS_LIMIT = 100
@@ -24,7 +24,7 @@ function useDataUnionMembers() {
     }, [])
 
     useEffect(() => () => {
-        // Cancel generator on unmount
+        // Cancel generators on unmount
         if (generator.current != null) {
             generator.current.return('Canceled')
             generator.current = null
@@ -34,6 +34,7 @@ function useDataUnionMembers() {
     const load = useCallback(async (dataUnionId) => {
         setLoading(true)
         try {
+            // Cancel previous generator
             if (generator.current != null) {
                 generator.current.return('Canceled')
                 generator.current = null
@@ -69,8 +70,9 @@ function useDataUnionMembers() {
     }, [])
 
     const search = useCallback(async (dataUnionId, text) => {
-        const results = await searchDataUnionMembers(dataUnionId, text)
-        return results.slice(0, VISIBLE_MEMBERS_LIMIT)
+        const searchResults = await searchDataUnionMembers(dataUnionId, text)
+        const resultsWithStatuses = await getSelectedMemberStatuses(dataUnionId, searchResults.slice(0, VISIBLE_MEMBERS_LIMIT))
+        return resultsWithStatuses
     }, [])
 
     return useMemo(() => ({

--- a/app/src/marketplace/modules/dataUnion/hooks/useDataUnionMembers.jsx
+++ b/app/src/marketplace/modules/dataUnion/hooks/useDataUnionMembers.jsx
@@ -70,7 +70,6 @@ function useDataUnionMembers() {
 
     const search = useCallback(async (dataUnionId, text) => {
         const results = await searchDataUnionMembers(dataUnionId, text)
-        console.log('Res', results)
         return results.slice(0, VISIBLE_MEMBERS_LIMIT)
     }, [])
 

--- a/app/src/marketplace/modules/dataUnion/hooks/useDataUnionMembers.jsx
+++ b/app/src/marketplace/modules/dataUnion/hooks/useDataUnionMembers.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback, useState, useContext, useRef, useEffect } 
 
 import useIsMounted from '$shared/hooks/useIsMounted'
 import { useThrottled } from '$shared/hooks/wrapCallback'
-import { getAllMemberEvents, removeMembers } from '../services'
+import { getMemberStatuses, removeMembers, searchDataUnionMembers } from '../services'
 
 const DataUnionMembersContext = React.createContext({})
 const VISIBLE_MEMBERS_LIMIT = 100
@@ -39,7 +39,7 @@ function useDataUnionMembers() {
                 generator.current = null
                 reset()
             }
-            generator.current = getAllMemberEvents(dataUnionId)
+            generator.current = getMemberStatuses(dataUnionId)
 
             // eslint-disable-next-line no-restricted-syntax
             for await (const event of generator.current) {
@@ -68,11 +68,11 @@ function useDataUnionMembers() {
         }
     }, [])
 
-    const search = useCallback((text) => (
-        membersRef.current
-            .filter((m) => ((text && text.length > 0) ? m.address.includes(text) : true))
-            .slice(0, VISIBLE_MEMBERS_LIMIT)
-    ), [])
+    const search = useCallback(async (dataUnionId, text) => {
+        const results = await searchDataUnionMembers(dataUnionId, text)
+        console.log('Res', results)
+        return results.slice(0, VISIBLE_MEMBERS_LIMIT)
+    }, [])
 
     return useMemo(() => ({
         loading,

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -605,8 +605,87 @@ export async function* getJoinsAndParts(id: DataUnionId, fromTimestamp: number):
     /* eslint-enable no-restricted-syntax, no-await-in-loop */
 }
 
+export const getMemberStatistics = async (id: DataUnionId, fromTimestamp: number, toTimestamp: number = Date.now()): Promise<Array<any>> => {
+    const accuracy = 'HOUR' // HOUR or DAY
+    const result = await post({
+        url: 'http://192.168.1.3:8000/subgraphs/name/streamr-dev/dataunion',
+        data: {
+            query: `
+                query {
+                    dataUnionStatsBuckets(
+                        where: {
+                            type: "${accuracy}",
+                            startDate_gte: ${Math.floor(fromTimestamp / 1000)},
+                            endDate_lte: ${Math.ceil(toTimestamp / 1000)}
+                        },
+                        orderBy: startDate,
+                    ) {
+                        startDate,
+                        endDate,
+                        memberCountAtStart,
+                        memberCountChange,
+                    }
+                }
+            `,
+        },
+        useAuthorization: false,
+    })
+    return result.data.dataUnionStatsBuckets
+}
+
+export const getDataUnionMembers = async (id: DataUnionId, limit: number = 100): Promise<Array<string>> => {
+    const result = await post({
+        url: 'http://192.168.1.3:8000/subgraphs/name/streamr-dev/dataunion',
+        data: {
+            query: `
+                query {
+                    dataUnions(where: { mainchainAddress: "${id.toLowerCase()}" }) {
+                        members(first: ${Math.floor(limit)}, orderBy: address, orderDirection: asc) {
+                            address
+                        }
+                    }
+                }
+            `,
+        },
+        useAuthorization: false,
+    })
+    if (result.data.dataUnions.length > 0) {
+        return result.data.dataUnions[0].members.map((m) => m.address)
+    }
+    return []
+}
+
+export const searchDataUnionMembers = async (id: DataUnionId, query: string): Promise<Array<string>> => {
+    const result = await post({
+        url: 'http://192.168.1.3:8000/subgraphs/name/streamr-dev/dataunion',
+        data: {
+            query: `
+                query {
+                    memberSearch(text: "${query}:*") {
+                        address
+                        dataunion {
+                            mainchainAddress
+                        }
+                    }
+                }
+            `,
+        },
+        useAuthorization: false,
+    })
+    if (result && result.data && result.data.memberSearch) {
+        // With limitations in full text search in The Graph,
+        // we cannot do filtering on the query itself so we
+        // have to manually pick results only for this dataunion id.
+        const duMembers = result.data.memberSearch
+            .filter((m) => m.dataunion.mainchainAddress === id)
+            .map((m) => m.address)
+        return duMembers
+    }
+    return []
+}
+
 // eslint-disable-next-line camelcase
-async function* deprecated_getMemberEvents(id: DataUnionId, timestampFrom: number = 0): any {
+async function* deprecated_getMemberStatuses(id: DataUnionId, timestampFrom: number = 0): any {
     const dataUnion = await getDataUnion(id)
     const client = createClient()
     await client.ensureConnected()
@@ -635,43 +714,33 @@ async function* deprecated_getMemberEvents(id: DataUnionId, timestampFrom: numbe
     /* eslint-enable no-restricted-syntax */
 }
 
-export async function* getMemberEventsFromBlock(id: DataUnionId, blockNumber: number): any {
+async function* getMemberStatusesWithClient(id: DataUnionId, members: Array<string>): any {
     const client = createClient()
-    const web3 = getSidechainWeb3()
 
     /* eslint-disable no-restricted-syntax, no-await-in-loop */
-    for await (const joins of getSidechainEvents(id, 'MemberJoined', blockNumber)) {
-        for (const e of joins) {
-            const memberAddress = e.returnValues.member
-            const block = await web3.eth.getBlock(e.blockHash)
-            if (block) {
-                const dataUnion = client.getDataUnion(id)
-                const memberData = await dataUnion.getMemberStats(memberAddress)
-                yield {
-                    ...memberData,
-                    address: memberAddress,
-                }
-            }
+    for (const memberAddress of members) {
+        const dataUnion = client.getDataUnion(id)
+        const memberData = await dataUnion.getMemberStats(memberAddress)
+        yield {
+            ...memberData,
+            address: memberAddress,
         }
     }
     /* eslint-enable no-restricted-syntax, no-await-in-loop */
 }
 
-export async function* getMemberEventsFromTimestamp(id: DataUnionId, timestamp: number = 0): any {
-    const web3 = getSidechainWeb3()
-    const fromBlock = await getBlockNumberForTimestamp(web3, Math.floor(timestamp / 1000))
-
-    yield* getMemberEventsFromBlock(id, fromBlock)
+export async function* getMemberStatusesFromTheGraph(id: DataUnionId): any {
+    const members = await getDataUnionMembers(id)
+    yield* getMemberStatusesWithClient(id, members)
 }
 
-export async function* getAllMemberEvents(id: DataUnionId): any {
+export async function* getMemberStatuses(id: DataUnionId): any {
     const version = await getDataUnionVersion(id)
 
     if (version === 1) {
-        yield* deprecated_getMemberEvents(id)
+        yield* deprecated_getMemberStatuses(id)
     } else if (version === 2) {
-        const duFirstPossibleBlock = parseInt(process.env.DATA_UNION_FACTORY_SIDECHAIN_CREATION_BLOCK, 10)
-        yield* getMemberEventsFromBlock(id, duFirstPossibleBlock)
+        yield* getMemberStatusesFromTheGraph(id)
     }
 }
 

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -608,7 +608,7 @@ export async function* getJoinsAndParts(id: DataUnionId, fromTimestamp: number):
 export const getMemberStatistics = async (id: DataUnionId, fromTimestamp: number, toTimestamp: number = Date.now()): Promise<Array<any>> => {
     const accuracy = 'HOUR' // HOUR or DAY
     const result = await post({
-        url: 'http://192.168.1.3:8000/subgraphs/name/streamr-dev/dataunion',
+        url: `${process.env.THE_GRAPH_API_URL}/subgraphs/name/streamr-dev/dataunion`,
         data: {
             query: `
                 query {
@@ -635,7 +635,7 @@ export const getMemberStatistics = async (id: DataUnionId, fromTimestamp: number
 
 export const getDataUnionMembers = async (id: DataUnionId, limit: number = 100): Promise<Array<string>> => {
     const result = await post({
-        url: 'http://192.168.1.3:8000/subgraphs/name/streamr-dev/dataunion',
+        url: `${process.env.THE_GRAPH_API_URL}/subgraphs/name/streamr-dev/dataunion`,
         data: {
             query: `
                 query {
@@ -655,13 +655,13 @@ export const getDataUnionMembers = async (id: DataUnionId, limit: number = 100):
     return []
 }
 
-export const searchDataUnionMembers = async (id: DataUnionId, query: string): Promise<Array<string>> => {
+export const searchDataUnionMembers = async (id: DataUnionId, query: string, limit: number = 100): Promise<Array<string>> => {
     const result = await post({
-        url: 'http://192.168.1.3:8000/subgraphs/name/streamr-dev/dataunion',
+        url: `${process.env.THE_GRAPH_API_URL}/subgraphs/name/streamr-dev/dataunion`,
         data: {
             query: `
                 query {
-                    memberSearch(text: "${query}:*") {
+                    members(where: { addressString_contains: "${query}"}, first: ${Math.floor(limit)}) {
                         address
                         dataunion {
                             mainchainAddress
@@ -672,14 +672,14 @@ export const searchDataUnionMembers = async (id: DataUnionId, query: string): Pr
         },
         useAuthorization: false,
     })
-    if (result && result.data && result.data.memberSearch) {
+    if (result && result.data && result.data.members) {
         // With limitations in full text search in The Graph,
         // we cannot do filtering on the query itself so we
-        // have to manually pick results only for this dataunion id.
-        const duMembers = result.data.memberSearch
+        // have to manually pick results only for this dataunion.
+        const members = result.data.members
             .filter((m) => m.dataunion.mainchainAddress === id)
             .map((m) => m.address)
-        return duMembers
+        return members
     }
     return []
 }

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -714,6 +714,18 @@ async function* deprecated_getMemberStatuses(id: DataUnionId, timestampFrom: num
     /* eslint-enable no-restricted-syntax */
 }
 
+export async function getSelectedMemberStatuses(id: DataUnionId, members: Array<string>): any {
+    const statuses = []
+
+    /* eslint-disable no-restricted-syntax, no-await-in-loop */
+    for await (const status of getMemberStatusesWithClient(id, members)) {
+        statuses.push(status)
+    }
+    /* eslint-enable no-restricted-syntax, no-await-in-loop */
+
+    return statuses
+}
+
 async function* getMemberStatusesWithClient(id: DataUnionId, members: Array<string>): any {
     const client = createClient()
 

--- a/app/src/userpages/components/DataUnionPage/ManageMembers.jsx
+++ b/app/src/userpages/components/DataUnionPage/ManageMembers.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useEffect, useState, useCallback, useMemo } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import styled from 'styled-components'
 
 import Button from '$shared/components/Button'
@@ -11,6 +11,7 @@ import Text from '$ui/Text'
 import SvgIcon from '$shared/components/SvgIcon'
 import UnstyledLoadingIndicator from '$shared/components/LoadingIndicator'
 import useIsMounted from '$shared/hooks/useIsMounted'
+import { useDebounced } from '$shared/hooks/wrapCallback'
 import useDataUnionMembers from '$mp/modules/dataUnion/hooks/useDataUnionMembers'
 
 const Container = styled.div`
@@ -195,10 +196,12 @@ const ManageMembers = ({ dataUnion, className }: Props) => {
         load()
     }, [loadMembers, dataUnionId])
 
+    const debouncedSetSearch = useDebounced(setSearch, 250)
+
     const onSearchChange = useCallback((e) => {
         const search = e.target.value.trim()
-        setSearch(search)
-    }, [setSearch])
+        debouncedSetSearch(search)
+    }, [debouncedSetSearch])
 
     const removeMember = useCallback(async (memberAddress: string) => {
         setProcessingMembers((prev) => [
@@ -219,10 +222,12 @@ const ManageMembers = ({ dataUnion, className }: Props) => {
     useEffect(() => {
         const doSearch = async () => {
             try {
+                console.log('Starting search with', search)
                 const results = await searchMembers(dataUnionId, search)
 
                 if (isMounted()) {
                     setSearchResults(results)
+                    console.log('End search with results', results, 'for', search)
                 }
             } catch (e) {
                 console.error('Could not load search results', e)

--- a/app/src/userpages/components/DataUnionPage/ManageMembers.jsx
+++ b/app/src/userpages/components/DataUnionPage/ManageMembers.jsx
@@ -173,6 +173,7 @@ const ManageMembers = ({ dataUnion, className }: Props) => {
     const isMounted = useIsMounted()
     const dataUnionId = dataUnion && dataUnion.id
     const [search, setSearch] = useState('')
+    const [searchResults, setSearchResults] = useState([])
     const [processingMembers, setProcessingMembers] = useState([])
     const {
         loading: loadingMembers,
@@ -215,9 +216,20 @@ const ManageMembers = ({ dataUnion, className }: Props) => {
         }
     }, [dataUnionId, removeMembers, isMounted])
 
-    const searchResults = useMemo(() => (
-        searchMembers(search)
-    ), [search, searchMembers])
+    useEffect(() => {
+        const doSearch = async () => {
+            try {
+                const results = await searchMembers(dataUnionId, search)
+
+                if (isMounted()) {
+                    setSearchResults(results)
+                }
+            } catch (e) {
+                console.error('Could not load search results', e)
+            }
+        }
+        doSearch()
+    }, [search, dataUnionId, isMounted, searchMembers])
 
     const listing = search.length > 0 ? searchResults : members
 

--- a/app/src/userpages/components/DataUnionPage/Management.jsx
+++ b/app/src/userpages/components/DataUnionPage/Management.jsx
@@ -114,7 +114,7 @@ const Management = ({ product, joinRequests, dataUnion, className }: Props) => {
                     />
                 ) : (
                     <MembersGraphV2
-                        memberCount={(memberCount && memberCount.total) || 0}
+                        memberCount={(memberCount && memberCount.active) || 0}
                         shownDays={days}
                         dataUnionAddress={dataUnion && dataUnion.id}
                     />


### PR DESCRIPTION
Data for member listing and member graph is now loaded from subgraph. Also member searching is using the same subgraph.

This can be tested locally once we have this subgraph deployed on streamr-docker-dev.