### PR TITLE
[FRONT-427] Remove ghost streams from product

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useContext, useMemo, useEffect, useCallback, useState, useRef } from 'react'
+import React, { useContext, useMemo, useEffect } from 'react'
 import { withRouter } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
@@ -21,7 +21,7 @@ import useProduct from '$mp/containers/ProductController/useProduct'
 import useEthereumIdentities from '$shared/modules/integrationKey/hooks/useEthereumIdentities'
 import useDataUnionSecrets from '$mp/modules/dataUnion/hooks/useDataUnionSecrets'
 import ResourceNotFoundError, { ResourceType } from '$shared/errors/ResourceNotFoundError'
-import { selectFetchingStreams, selectHasMoreResults } from '$mp/modules/streams/selectors'
+import { selectFetchingStreams } from '$mp/modules/streams/selectors'
 import useWhitelist from '$mp/modules/contractProduct/hooks/useWhitelist'
 import useModal from '$shared/hooks/useModal'
 
@@ -39,8 +39,6 @@ import CropImageModal from './CropImageModal'
 import WhitelistEditModal from './WhitelistEditModal'
 
 import styles from './editProductPage.pcss'
-
-const STREAMS_PAGE_SIZE = 999
 
 const EditProductPage = ({ product }: { product: Product }) => {
     const {
@@ -60,55 +58,33 @@ const EditProductPage = ({ product }: { product: Product }) => {
         loadDataUnion,
         loadDataUnionStats,
         clearStreams,
-        loadStreams,
+        loadAllStreams,
         resetDataUnion,
     } = useController()
 
     const { load: loadDataUnionSecrets, reset: resetDataUnionSecrets } = useDataUnionSecrets()
     const { load: loadWhiteWhitelistedAdresses, reset: resetWhiteWhitelistedAdresses } = useWhitelist()
     const fetchingAllStreams = useSelector(selectFetchingStreams)
-    const hasMoreResults = useSelector(selectHasMoreResults)
-    const [nextPage, setNextPage] = useState(0)
-    const loadedPageRef = useRef(0)
     const { isOpen: isDataUnionDeployDialogOpen } = useModal('dataUnion.DEPLOY')
     const { isOpen: isConfirmSaveDialogOpen } = useModal('confirmSave')
     const { isOpen: isPublishDialogOpen } = useModal('publish')
 
-    const doLoadStreams = useCallback((page = 0) => {
-        loadedPageRef.current = page
-        loadStreams({
-            max: STREAMS_PAGE_SIZE,
-            offset: page * STREAMS_PAGE_SIZE,
-        }).then(() => {
-            setNextPage(page + 1)
-        })
-    }, [loadStreams])
-
     const productId = product.id
     // Load categories and streams
     useEffect(() => {
-        clearStreams()
         loadContractProductSubscription(productId)
         loadCategories()
         loadProductStreams(productId)
         loadWhiteWhitelistedAdresses(productId)
-        doLoadStreams()
+        loadAllStreams()
     }, [
         loadCategories,
         loadContractProductSubscription,
         loadProductStreams,
         productId,
-        clearStreams,
-        doLoadStreams,
+        loadAllStreams,
         loadWhiteWhitelistedAdresses,
     ])
-
-    // Load more streams if we didn't get all in the initial load
-    useEffect(() => {
-        if (!fetchingAllStreams && hasMoreResults && nextPage > loadedPageRef.current) {
-            doLoadStreams(nextPage)
-        }
-    }, [nextPage, fetchingAllStreams, hasMoreResults, doLoadStreams])
 
     // Load eth identities & data union (used to determine if owner account is linked)
     const { load: loadEthIdentities } = useEthereumIdentities()
@@ -143,11 +119,12 @@ const EditProductPage = ({ product }: { product: Product }) => {
         loadDataUnionSecrets,
     ])
 
-    // clear data union secrets when unmounting
+    // clear streams & data union secrets when unmounting
     useEffect(() => () => {
         resetDataUnion()
         resetDataUnionSecrets()
-    }, [resetDataUnion, resetDataUnionSecrets])
+        clearStreams()
+    }, [resetDataUnion, resetDataUnionSecrets, clearStreams])
 
     // clear whitelisted addresses when unmounting
     useEffect(() => () => {

--- a/app/src/marketplace/containers/EditProductPage/tests/usePublish.test.jsx
+++ b/app/src/marketplace/containers/EditProductPage/tests/usePublish.test.jsx
@@ -9,6 +9,7 @@ import * as contractProductServices from '$mp/modules/contractProduct/services'
 import * as dataUnionServices from '$mp/modules/dataUnion/services'
 import * as transactionActions from '$mp/modules/transactions/actions'
 import * as productServices from '$mp/modules/product/services'
+import * as streamsServices from '$mp/modules/streams/services'
 
 import { transactionStates, transactionTypes } from '$shared/utils/constants'
 import usePublish, { publishModes, actionsTypes } from '../usePublish'
@@ -501,6 +502,16 @@ describe('usePublish', () => {
                     .subscribe('finish', finishFn)
 
                 const putProductStub = jest.spyOn(productServices, 'putProduct').mockImplementation(() => Promise.resolve())
+                const getStreamsStub = jest.spyOn(streamsServices, 'getAllStreams')
+                    .mockImplementation(() => Promise.resolve([{
+                        id: '1',
+                    }, {
+                        id: '2',
+                    }, {
+                        id: '3',
+                    }, {
+                        id: '4',
+                    }]))
 
                 await result.queue.start()
 
@@ -511,6 +522,77 @@ describe('usePublish', () => {
                     streams: ['2', '3', '4'],
                     pendingChanges: undefined,
                 }, '1')
+                expect(getStreamsStub).toHaveBeenCalled()
+                expect(startedFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
+                expect(statusFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES, transactionStates.CONFIRMED)
+                expect(readyFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
+                expect(finishFn).toHaveBeenCalled()
+            })
+
+            it('removes streams from pending changes that do not exist', async () => {
+                let publish
+                function Test() {
+                    publish = usePublish()
+                    return null
+                }
+
+                mount((
+                    <Test />
+                ))
+
+                const product = {
+                    id: '1',
+                    name: 'Name',
+                    description: 'Description',
+                    streams: ['1', '3'],
+                    state: 'DEPLOYED',
+                    pendingChanges: {
+                        name: 'New name',
+                        streams: ['2', '3', '4'],
+                    },
+                }
+
+                let result
+                await act(async () => {
+                    result = await publish(product)
+                })
+
+                expect(result.mode).toBe(publishModes.REPUBLISH)
+                expect(result.queue.getActions().map(({ id }) => id)).toStrictEqual([
+                    actionsTypes.PUBLISH_PENDING_CHANGES,
+                ])
+                expect(result.queue.needsWeb3()).toBe(false)
+                expect(result.queue.needsOwner()).toStrictEqual([])
+
+                const startedFn = jest.fn()
+                const statusFn = jest.fn()
+                const readyFn = jest.fn()
+                const finishFn = jest.fn()
+
+                result.queue
+                    .subscribe('started', startedFn)
+                    .subscribe('status', statusFn)
+                    .subscribe('ready', readyFn)
+                    .subscribe('finish', finishFn)
+
+                const putProductStub = jest.spyOn(productServices, 'putProduct').mockImplementation(() => Promise.resolve())
+                const getStreamsStub = jest.spyOn(streamsServices, 'getAllStreams')
+                    .mockImplementation(() => Promise.resolve([{
+                        id: '1',
+                    }, {
+                        id: '2',
+                    }]))
+
+                await result.queue.start()
+
+                expect(putProductStub).toBeCalledWith({
+                    id: '1',
+                    name: 'New name',
+                    description: 'Description',
+                    streams: ['2'],
+                    pendingChanges: undefined,
+                }, '1')
+                expect(getStreamsStub).toHaveBeenCalled()
                 expect(startedFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
                 expect(statusFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES, transactionStates.CONFIRMED)
                 expect(readyFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
@@ -1093,6 +1175,16 @@ describe('usePublish', () => {
                 }
 
                 jest.spyOn(contractProductServices, 'redeployProduct').mockImplementation(() => tx)
+                const getStreamsStub = jest.spyOn(streamsServices, 'getAllStreams')
+                    .mockImplementation(() => Promise.resolve([{
+                        id: '1',
+                    }, {
+                        id: '2',
+                    }, {
+                        id: '3',
+                    }, {
+                        id: '4',
+                    }]))
 
                 const startedFn = jest.fn()
                 const statusFn = jest.fn()
@@ -1123,6 +1215,7 @@ describe('usePublish', () => {
                 expect(startedFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
                 expect(statusFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES, transactionStates.CONFIRMED)
                 expect(readyFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
+                expect(getStreamsStub).toHaveBeenCalled()
                 expect(putProductStub.mock.calls[0][0]).toMatchObject({
                     id: '1',
                     name: 'New name',
@@ -1167,6 +1260,16 @@ describe('usePublish', () => {
                 }
                 const updateContractStub = jest.spyOn(contractProductServices, 'updateContractProduct').mockImplementation(() => tx)
                 const addTransactionStub = jest.spyOn(transactionActions, 'addTransaction')
+                const getStreamsStub = jest.spyOn(streamsServices, 'getAllStreams')
+                    .mockImplementation(() => Promise.resolve([{
+                        id: '1',
+                    }, {
+                        id: '2',
+                    }, {
+                        id: '3',
+                    }, {
+                        id: '4',
+                    }]))
 
                 const product = {
                     id: '1',
@@ -1238,6 +1341,7 @@ describe('usePublish', () => {
                 expect(addTransactionStub).toBeCalledWith(hash, transactionTypes.UPDATE_CONTRACT_PRODUCT)
                 expect(readyFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
                 expect(readyFn).toHaveBeenCalledWith(actionsTypes.UPDATE_CONTRACT_PRODUCT)
+                expect(getStreamsStub).toHaveBeenCalled()
                 expect(putProductStub.mock.calls[0][0]).toMatchObject({
                     id: '1',
                     name: 'New name',
@@ -1681,6 +1785,16 @@ describe('usePublish', () => {
                 const setAdminFeeStub = jest.spyOn(dataUnionServices, 'setAdminFee').mockImplementation(() => tx)
                 const putProductStub = jest.spyOn(productServices, 'putProduct').mockImplementation(() => Promise.resolve())
                 const addTransactionStub = jest.spyOn(transactionActions, 'addTransaction')
+                const getStreamsStub = jest.spyOn(streamsServices, 'getAllStreams')
+                    .mockImplementation(() => Promise.resolve([{
+                        id: '1',
+                    }, {
+                        id: '2',
+                    }, {
+                        id: '3',
+                    }, {
+                        id: '4',
+                    }]))
 
                 const product = {
                     id: '1',
@@ -1741,6 +1855,7 @@ describe('usePublish', () => {
                 expect(startedFn).toHaveBeenCalledWith(actionsTypes.PUBLISH_PENDING_CHANGES)
                 expect(startedFn).toHaveBeenCalledWith(actionsTypes.UPDATE_ADMIN_FEE)
 
+                expect(getStreamsStub).toHaveBeenCalled()
                 expect(putProductStub).toBeCalledWith({
                     id: '1',
                     name: 'New name',
@@ -1805,6 +1920,16 @@ describe('usePublish', () => {
                 const updateContractStub = jest.spyOn(contractProductServices, 'updateContractProduct').mockImplementation(() => tx2)
                 const putProductStub = jest.spyOn(productServices, 'putProduct').mockImplementation(() => Promise.resolve())
                 const addTransactionStub = jest.spyOn(transactionActions, 'addTransaction')
+                const getStreamsStub = jest.spyOn(streamsServices, 'getAllStreams')
+                    .mockImplementation(() => Promise.resolve([{
+                        id: '1',
+                    }, {
+                        id: '2',
+                    }, {
+                        id: '3',
+                    }, {
+                        id: '4',
+                    }]))
 
                 const product = {
                     id: '1',
@@ -1876,6 +2001,7 @@ describe('usePublish', () => {
                 expect(startedFn).toHaveBeenCalledWith(actionsTypes.UPDATE_ADMIN_FEE)
                 expect(startedFn).toHaveBeenCalledWith(actionsTypes.UPDATE_CONTRACT_PRODUCT)
 
+                expect(getStreamsStub).toHaveBeenCalled()
                 expect(putProductStub.mock.calls[0][0]).toMatchObject({
                     id: '1',
                     name: 'New name',

--- a/app/src/marketplace/containers/ProductController/index.jsx
+++ b/app/src/marketplace/containers/ProductController/index.jsx
@@ -20,7 +20,7 @@ import useLoadProductStreamsCallback from './useLoadProductStreamsCallback'
 import useDataUnionLoadCallback from './useDataUnionLoadCallback'
 import useDataUnionStatsLoadCallback from './useDataUnionStatsLoadCallback'
 import useRelatedProductsLoadCallback from './useRelatedProductsLoadCallback'
-import useLoadStreamsCallback from './useLoadStreamsCallback'
+import useLoadAllStreamsCallback from './useLoadAllStreamsCallback'
 import useClearStreamsCallback from './useClearStreamsCallback'
 import useResetDataUnionCallback from './useResetDataUnionCallback'
 
@@ -35,7 +35,7 @@ type ContextProps = {
     loadDataUnion: Function,
     loadDataUnionStats: Function,
     loadRelatedProducts: Function,
-    loadStreams: Function,
+    loadAllStreams: Function,
     clearStreams: Function,
     resetDataUnion: Function,
 }
@@ -112,7 +112,7 @@ function useProductController() {
     const loadDataUnion = useDataUnionLoadCallback()
     const loadDataUnionStats = useDataUnionStatsLoadCallback()
     const loadRelatedProducts = useRelatedProductsLoadCallback()
-    const loadStreams = useLoadStreamsCallback()
+    const loadAllStreams = useLoadAllStreamsCallback()
     const clearStreams = useClearStreamsCallback()
     const resetDataUnion = useResetDataUnionCallback()
 
@@ -127,7 +127,7 @@ function useProductController() {
         loadDataUnion,
         loadDataUnionStats,
         loadRelatedProducts,
-        loadStreams,
+        loadAllStreams,
         clearStreams,
         resetDataUnion,
     }), [
@@ -141,7 +141,7 @@ function useProductController() {
         loadDataUnion,
         loadDataUnionStats,
         loadRelatedProducts,
-        loadStreams,
+        loadAllStreams,
         clearStreams,
         resetDataUnion,
     ])

--- a/app/src/marketplace/containers/ProductController/useLoadAllStreamsCallback.js
+++ b/app/src/marketplace/containers/ProductController/useLoadAllStreamsCallback.js
@@ -5,15 +5,15 @@ import { useDispatch } from 'react-redux'
 
 import usePending from '$shared/hooks/usePending'
 
-import { getStreams } from '$mp/modules/streams/actions'
+import { getAllStreams } from '$mp/modules/streams/actions'
 
-export default function useLoadStreamsCallback() {
+export default function useLoadAllStreamsCallback() {
     const dispatch = useDispatch()
     const { wrap } = usePending('streams.LOAD')
 
     return useCallback(async (params: Object = {}) => (
         wrap(async () => {
-            await dispatch(getStreams(params))
+            await dispatch(getAllStreams(params))
         })
     ), [wrap, dispatch])
 }

--- a/app/src/marketplace/flowtype/store-state.js
+++ b/app/src/marketplace/flowtype/store-state.js
@@ -92,7 +92,6 @@ export type StreamsState = {
     ids: StreamIdList,
     fetching: boolean,
     error: ?ErrorInUi,
-    hasMoreResults: boolean,
 }
 
 // Purchase

--- a/app/src/marketplace/modules/streams/actions.js
+++ b/app/src/marketplace/modules/streams/actions.js
@@ -22,9 +22,8 @@ import type {
 
 const getStreamsRequest: ReduxActionCreator = createAction(GET_STREAMS_REQUEST)
 
-const getStreamsSuccess: StreamsActionCreator = createAction(GET_STREAMS_SUCCESS, (streams: StreamList, hasMoreResults: boolean) => ({
+const getStreamsSuccess: StreamsActionCreator = createAction(GET_STREAMS_SUCCESS, (streams: StreamList) => ({
     streams,
-    hasMoreResults,
 }))
 
 const getStreamsFailure: StreamsErrorActionCreator = createAction(GET_STREAMS_FAILURE, (error: ErrorInUi) => ({
@@ -33,13 +32,13 @@ const getStreamsFailure: StreamsErrorActionCreator = createAction(GET_STREAMS_FA
 
 export const clearStreamList: ReduxActionCreator = createAction(CLEAR_STREAM_LIST)
 
-export const getStreams = (params: Object = {}) => (dispatch: Function) => {
+export const getAllStreams = (params: Object = {}) => (dispatch: Function) => {
     dispatch(getStreamsRequest())
-    return api.getStreams(params)
-        .then(({ streams, hasMoreResults }) => {
+    return api.getAllStreams(params)
+        .then((streams) => {
             const { result, entities } = normalize(streams, streamsSchema)
             dispatch(updateEntities(entities))
-            dispatch(getStreamsSuccess(result, hasMoreResults))
+            dispatch(getStreamsSuccess(result))
         }, (error) => {
             dispatch(getStreamsFailure(error))
         })

--- a/app/src/marketplace/modules/streams/reducer.js
+++ b/app/src/marketplace/modules/streams/reducer.js
@@ -19,7 +19,6 @@ export const initialState: StreamsState = {
     ids: [],
     fetching: false,
     error: null,
-    hasMoreResults: false,
 }
 
 const reducer: (StreamsState) => StreamsState = handleActions({
@@ -39,7 +38,6 @@ const reducer: (StreamsState) => StreamsState = handleActions({
 
         return {
             ids,
-            hasMoreResults: action.payload.hasMoreResults,
             fetching: false,
             error: null,
         }
@@ -54,7 +52,6 @@ const reducer: (StreamsState) => StreamsState = handleActions({
     [CLEAR_STREAM_LIST]: (state: StreamsState) => ({
         ...state,
         ids: [],
-        hasMoreResults: false,
     }),
 }, initialState)
 

--- a/app/src/marketplace/modules/streams/selectors.js
+++ b/app/src/marketplace/modules/streams/selectors.js
@@ -33,8 +33,3 @@ export const selectStreamsError: (StoreState) => ?ErrorInUi = createSelector(
     selectStreamsState,
     (subState: StreamsState): ?ErrorInUi => subState.error,
 )
-
-export const selectHasMoreResults: (StoreState) => boolean = createSelector(
-    selectStreamsState,
-    (subState: StreamsState): boolean => subState.hasMoreResults,
-)

--- a/app/src/marketplace/modules/streams/services.js
+++ b/app/src/marketplace/modules/streams/services.js
@@ -5,7 +5,7 @@ import type { ApiResult } from '$shared/flowtype/common-types'
 import type { StreamId, StreamList } from '$shared/flowtype/stream-types'
 import routes from '$routes'
 
-export const getStreams = (params: any): ApiResult<{
+export const getStreams = (params: Object): ApiResult<{
     streams: StreamList,
     hasMoreResults: boolean,
 }> => {
@@ -29,6 +29,40 @@ export const getStreams = (params: any): ApiResult<{
             streams: nextParams.max ? streams.splice(0, nextParams.max - 1) : streams,
             hasMoreResults: !!nextParams.max && streams.length > 0,
         }))
+}
+
+const STREAMS_PAGE_SIZE = 999
+
+export async function* getPagedStreams(params: Object): any {
+    let page = 0
+    let hasMore = false
+
+    do {
+        // eslint-disable-next-line no-await-in-loop
+        const { streams, hasMoreResults } = await getStreams({
+            ...(params || {}),
+            max: STREAMS_PAGE_SIZE,
+            offset: page * STREAMS_PAGE_SIZE,
+        })
+        page += 1
+        hasMore = hasMoreResults
+
+        yield streams
+    } while (hasMore)
+}
+
+export async function getAllStreams(params: Object): any {
+    let streams = []
+
+    // eslint-disable-next-line no-restricted-syntax, no-await-in-loop
+    for await (const pagedStreams of getPagedStreams(params)) {
+        streams = [
+            ...streams,
+            ...pagedStreams,
+        ]
+    }
+
+    return streams
 }
 
 export const getStreamData = (streamId: StreamId, fromTimestamp: number): ApiResult<Object> => get({

--- a/app/src/marketplace/modules/streams/types.js
+++ b/app/src/marketplace/modules/streams/types.js
@@ -5,9 +5,8 @@ import type { StreamIdList } from '$shared/flowtype/stream-types'
 
 export type StreamsAction = PayloadAction<{
     streams: StreamIdList,
-    hasMoreResults: boolean,
 }>
-export type StreamsActionCreator = (streams: StreamIdList, hasMoreResults: boolean) => StreamsAction
+export type StreamsActionCreator = (streams: StreamIdList) => StreamsAction
 
 export type StreamsErrorAction = PayloadAction<{
     error: ErrorFromApi

--- a/app/test/unit/modules/streams/actions.test.js
+++ b/app/test/unit/modules/streams/actions.test.js
@@ -13,7 +13,7 @@ describe('streams - actions', () => {
         jest.restoreAllMocks()
     })
 
-    describe('getStreams', () => {
+    describe('getAllStreams', () => {
         it('gets streams succesfully', async () => {
             const streams = [
                 {
@@ -46,13 +46,10 @@ describe('streams - actions', () => {
 
             const { result, entities } = normalize(streams, streamsSchema)
 
-            const getStreamsStub = jest.spyOn(services, 'getStreams').mockImplementation(() => Promise.resolve({
-                streams,
-                hasMoreResults: false,
-            }))
+            const getStreamsStub = jest.spyOn(services, 'getAllStreams').mockImplementation(() => Promise.resolve(streams))
 
             const store = mockStore()
-            await store.dispatch(actions.getStreams())
+            await store.dispatch(actions.getAllStreams())
 
             const expectedActions = [
                 {
@@ -68,7 +65,6 @@ describe('streams - actions', () => {
                     type: constants.GET_STREAMS_SUCCESS,
                     payload: {
                         streams: result,
-                        hasMoreResults: false,
                     },
                 },
             ]
@@ -79,10 +75,10 @@ describe('streams - actions', () => {
 
         it('responds to errors', async () => {
             const error = new Error('Error')
-            jest.spyOn(services, 'getStreams').mockImplementation(() => Promise.reject(error))
+            jest.spyOn(services, 'getAllStreams').mockImplementation(() => Promise.reject(error))
 
             const store = mockStore()
-            await store.dispatch(actions.getStreams())
+            await store.dispatch(actions.getAllStreams())
 
             const expectedActions = [
                 {

--- a/app/test/unit/modules/streams/reducer.test.js
+++ b/app/test/unit/modules/streams/reducer.test.js
@@ -11,7 +11,6 @@ describe('streams - reducer', () => {
             ids: [],
             fetching: true,
             error: null,
-            hasMoreResults: false,
         }
 
         expect(reducer(undefined, {
@@ -25,14 +24,12 @@ describe('streams - reducer', () => {
             ids: [1, 2],
             fetching: false,
             error: null,
-            hasMoreResults: true,
         }
 
         expect(reducer(undefined, {
             type: constants.GET_STREAMS_SUCCESS,
             payload: {
                 streams: [1, 2],
-                hasMoreResults: true,
             },
         })).toStrictEqual(expectedState)
     })
@@ -42,20 +39,17 @@ describe('streams - reducer', () => {
             ids: [1, 2],
             fetching: false,
             error: null,
-            hasMoreResults: true,
         }
         const expectedState = {
             ids: [1, 2, 3, 4],
             fetching: false,
             error: null,
-            hasMoreResults: false,
         }
 
         expect(reducer(state, {
             type: constants.GET_STREAMS_SUCCESS,
             payload: {
                 streams: [3, 4],
-                hasMoreResults: false,
             },
         })).toStrictEqual(expectedState)
     })
@@ -65,20 +59,17 @@ describe('streams - reducer', () => {
             ids: [1, 2, 3],
             fetching: false,
             error: null,
-            hasMoreResults: true,
         }
         const expectedState = {
             ids: [1, 2, 3, 4, 5],
             fetching: false,
             error: null,
-            hasMoreResults: false,
         }
 
         expect(reducer(state, {
             type: constants.GET_STREAMS_SUCCESS,
             payload: {
                 streams: [3, 4, 5],
-                hasMoreResults: false,
             },
         })).toStrictEqual(expectedState)
     })
@@ -90,7 +81,6 @@ describe('streams - reducer', () => {
             ids: [],
             fetching: false,
             error,
-            hasMoreResults: false,
         }
 
         expect(reducer(undefined, {
@@ -106,13 +96,11 @@ describe('streams - reducer', () => {
             ids: ['1', '2'],
             fetching: false,
             error: null,
-            hasMoreResults: false,
         }
         const expectedState = {
             ids: [],
             fetching: false,
             error: null,
-            hasMoreResults: false,
         }
 
         expect(reducer(state, {


### PR DESCRIPTION
Handles an edge case where stream can be removed when it is in the product's pending changes. I added fetching of all the user's streams in the publish step which are then used to filter the selected streams.

**Steps to reproduce**

1) Go to Streams, create two streams (0x123...abc/1 and 0x123...abc/2)
2) Create a product, add both streams to it
3) Publish product
4) Edit product, deselect 0x123...abc/1
5) Publish product
6) Edit product, select 0x123...abc/1 
7) Save & exit (not publish)
8) Go to streams
9) Remove 0x123...abc/1 stream
10) Go to Products, edit product
11) Publish product

**Expected outcome**

Product is published

**Actual outcome**

Publish fails