### PR TITLE
[FRONT-430] Add generic error messages

### DIFF
--- a/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
@@ -96,8 +96,10 @@ const ProfileSettings = () => {
 
             if (isMounted()) {
                 if (error) {
+                    console.warn(error)
+
                     Notification.push({
-                        title: error.message,
+                        title: 'Save failed',
                         icon: NotificationIcon.ERROR,
                     })
                 } else if (uploaded) {

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -59,7 +59,7 @@ export const ProfilePage = () => {
                 console.warn(e)
 
                 Notification.push({
-                    title: e.message,
+                    title: 'Save failed',
                     icon: NotificationIcon.ERROR,
                 })
             }

--- a/app/src/userpages/components/StreamPage/Edit/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/ConfigureView/index.jsx
@@ -149,7 +149,7 @@ const ConfigureView = ({ stream, disabled, updateStream }: Props) => {
                 if (!isMounted()) { return }
 
                 Notification.push({
-                    title: err.message,
+                    title: 'Failed to detect fields',
                     icon: NotificationIcon.ERROR,
                 })
             } finally {

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -156,7 +156,7 @@ const UnstyledEdit = ({
             console.warn(e)
 
             Notification.push({
-                title: e.message,
+                title: 'Save failed',
                 icon: NotificationIcon.ERROR,
             })
         } finally {

--- a/app/src/userpages/components/StreamPage/Inspector.jsx
+++ b/app/src/userpages/components/StreamPage/Inspector.jsx
@@ -71,8 +71,10 @@ const UnstyledInspectorView = (props) => {
                 }
             } catch (e) {
                 if (!(e instanceof ResourceNotFoundError)) {
+                    console.warn(e)
+
                     Notification.push({
-                        title: e.message,
+                        title: 'Stream not found',
                         icon: NotificationIcon.ERROR,
                     })
                 }

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -79,8 +79,10 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
                     icon: NotificationIcon.CHECKMARK,
                 })
             } catch (e) {
+                console.warn(e)
+
                 Notification.push({
-                    title: e.message,
+                    title: `Stream ${canBeDeletedByCurrentUser ? 'delete' : 'remove'} failed`,
                     icon: NotificationIcon.ERROR,
                 })
             }

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -82,7 +82,7 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
                 console.warn(e)
 
                 Notification.push({
-                    title: `Stream ${canBeDeletedByCurrentUser ? 'delete' : 'remove'} failed`,
+                    title: `Stream ${canBeDeletedByCurrentUser ? 'deletion' : 'removal'} failed`,
                     icon: NotificationIcon.ERROR,
                 })
             }

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -150,8 +150,10 @@ const StreamList = () => {
         try {
             await dispatch(getStreams(...args))
         } catch (e) {
+            console.warn(e)
+
             Notification.push({
-                title: e.message,
+                title: 'Failed to fetch streams',
                 icon: NotificationIcon.ERROR,
             })
         }

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -461,7 +461,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
             }
 
             Notification.push({
-                title: e.message,
+                title: 'Save failed',
                 icon: NotificationIcon.ERROR,
             })
         } finally {

--- a/app/src/userpages/components/StreamPage/index.jsx
+++ b/app/src/userpages/components/StreamPage/index.jsx
@@ -68,8 +68,10 @@ const StreamPage = (props) => {
                 }
             } catch (e) {
                 if (!(e instanceof ResourceNotFoundError)) {
+                    console.warn(e)
+
                     Notification.push({
-                        title: e.message,
+                        title: 'Stream not found',
                         icon: NotificationIcon.ERROR,
                     })
                 }


### PR DESCRIPTION
Add generic error messages in places where before we were directly showing the error from backend. The actual error gets shown in console, but show a generic notification message in the UI.