### PR TITLE
[FRONT-710] Revert beneficiaryAddress if DU deploy fails

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/DeployDataUnionModal.jsx
+++ b/app/src/marketplace/containers/EditProductPage/DeployDataUnionModal.jsx
@@ -51,7 +51,7 @@ export const DeployDialog = ({ product, api, updateAddress }: DeployDialogProps)
     const [step, setStep] = useState(dontShowAgain ? steps.CONFIRM : steps.GUIDE)
     const [deployError, setDeployError] = useState(null)
     const [estimate, setEstimate] = useState(0)
-    const [address, setAddress] = useState(null)
+    const [address, setAddress] = useState(undefined)
     const isMounted = useIsMounted()
     const { web3Error, checkingWeb3 } = useWeb3Status()
 
@@ -128,7 +128,7 @@ export const DeployDialog = ({ product, api, updateAddress }: DeployDialogProps)
 
     // Update beneficiary address to product as soon as it changes
     useEffect(() => {
-        if (!!address && isEthereumAddress(address)) {
+        if (address === null || (!!address && isEthereumAddress(address))) {
             updateAddress(address)
         }
     }, [address, updateAddress])


### PR DESCRIPTION
Fixes an issue where when DU deploy fails, resetting the `beneficiaryAddress` didn't call the API to update product. 

There is a separate backend issue where setting the `beneficiaryAddress` to `null` does not save the value ([BACK-197](https://linear.app/streamr/issue/BACK-197/allow-resetting-beneficiaryaddress)) but this will at least make the call now.