### PR TITLE
Docs: Add warning labels about 5.x and 6.x client differences

### DIFF
--- a/app/src/docs/components/Warning/warning.pcss
+++ b/app/src/docs/components/Warning/warning.pcss
@@ -18,7 +18,7 @@
   margin-left: 4rem;
 
   &:last-of-type {
-    margin: -1.4rem 0 1rem 2rem;
+    margin: -1.6rem 0 1rem 2rem;
   }
 }
 

--- a/app/src/docs/content/streamrNetwork/usingALightNode.mdx
+++ b/app/src/docs/content/streamrNetwork/usingALightNode.mdx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-
+import Warning from '$docs/components/Warning'
 import { CodeSnippet } from '@streamr/streamr-layout'
 import docsLinks from '$shared/../docsLinks'
 
@@ -35,6 +35,12 @@ When using Node.js, import the library with:
 ```
 import { StreamrClient } from 'streamr-client'
 ```
+
+<Warning>
+
+The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client, (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same, however, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2021) data guarantees of 5.x clients may need to be reassessed.
+
+</Warning>
 
 Create an instance of `StreamrClient`, authenticated with an Ethereum private key:
 

--- a/app/src/docs/content/streamrNetwork/usingALightNode.mdx
+++ b/app/src/docs/content/streamrNetwork/usingALightNode.mdx
@@ -38,7 +38,7 @@ import { StreamrClient } from 'streamr-client'
 
 <Warning>
 
-The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client, (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same, however, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2021) data guarantees of 5.x clients may need to be reassessed.
+The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same. However, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2022), data guarantees of 5.x clients may need to be reassessed.
 
 </Warning>
 

--- a/app/src/docs/content/streams/endToEndEncryption.mdx
+++ b/app/src/docs/content/streams/endToEndEncryption.mdx
@@ -1,3 +1,5 @@
+import Warning from '$docs/components/Warning'
+
 # End-to-end encryption
 Confidentiality of events published on a stream can be guaranteed with end-to-end encryption. The publisher decides on a AES-256 symmetric group key and encrypts the messages in CTR mode before publishing them to the network. The subscribers must know this symmetric group key in order to decrypt the data.
 
@@ -14,3 +16,9 @@ c3 = AES_encrypt(m3, k2)
 ```
 
 Both the Javascript and the Java SDKs support this key update mechanism. It can be triggered by calling the `publish` method with a new symmetric group key as parameter.
+
+<Warning>
+
+The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client, (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same, however, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2021) data guarantees of 5.x clients may need to be reassessed.
+
+</Warning>

--- a/app/src/docs/content/streams/publishAndSubscribe.mdx
+++ b/app/src/docs/content/streams/publishAndSubscribe.mdx
@@ -27,6 +27,12 @@ Checkout the docs section for <Link to={docsLinks.usingALightNode}>Using a light
 - <a href="https://www.npmjs.com/package/streamr-client" target="_blank" rel="noopener noreferrer">Streamr Client NPM</a>
 - <a href="https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md" target="_blank" rel="noopener noreferrer">Streamr Client Github</a>
 
+<Warning>
+
+The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client, (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same, however, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2021) data guarantees of 5.x clients may need to be reassessed.
+
+</Warning>
+
 ### Publish and subscribe via MQTT, HTTP or Websocket
 You will need to run a Broker node and interface to it with either MQTT, HTTP or Websocket. Checkout the docs section for <Link to={docsLinks.connectingApplications}>Connecting Applications</Link>. 
 

--- a/app/src/docs/content/streams/publishAndSubscribe.mdx
+++ b/app/src/docs/content/streams/publishAndSubscribe.mdx
@@ -29,7 +29,7 @@ Checkout the docs section for <Link to={docsLinks.usingALightNode}>Using a light
 
 <Warning>
 
-The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client, (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same, however, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2021) data guarantees of 5.x clients may need to be reassessed.
+The current stable version of the Streamr Client is 5.x (at the time of writing, December 2021). The Brubeck era client (currently available as an alpha build) is version 6.x and above. The developer experience of the Streamr Client in 5.x and 6.x is the same. However, the 6.x client also runs as a light node in the network, whereas the 5.x era client communicates to a Streamr run node remotely. When the Streamr Network transitions into the Brubeck era (ETA 2022) data guarantees of 5.x clients may need to be reassessed.
 
 </Warning>
 


### PR DESCRIPTION
Just adding a minor reminder to developers about the differences between 5.x client and 6.x client.