### PR TITLE
Add opt-in for validateWeb3 timeout

### DIFF
--- a/app/src/marketplace/containers/ProductPage/Hero.jsx
+++ b/app/src/marketplace/containers/ProductPage/Hero.jsx
@@ -44,6 +44,7 @@ const getWhitelistStatus = async ({ productId, validate = false }: WhitelistStat
             await validateWeb3({
                 web3,
                 requireNetwork: false, // network check is done later if purchase is possible
+                unlockTimeout: true,
             })
         }
         const account = await web3.getDefaultAccount()

--- a/app/src/shared/hooks/useWeb3Status.js
+++ b/app/src/shared/hooks/useWeb3Status.js
@@ -32,6 +32,7 @@ export function useWeb3Status(requireWeb3: boolean = true): Result {
         try {
             await validateWeb3({
                 web3,
+                unlockTimeout: true,
             })
             if (!isMounted()) { return }
 


### PR DESCRIPTION
Follow up for https://github.com/streamr-dev/core-frontend/pull/1278 (FRONT-723), this makes the timeout for unlocking Metamask prompt optional. For example when logging in, it waits for the Metamask approval. Otherwise, it shows as failed before the user unlocks.