### PR TITLE
[FRONT-769] Switching network from purchase modal gives an error

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/usePublish.js
+++ b/app/src/marketplace/containers/EditProductPage/usePublish.js
@@ -64,7 +64,7 @@ export default function usePublish() {
         // load contract product
         let contractProduct
         try {
-            contractProduct = await getProductFromContract(product.id || '', true)
+            contractProduct = await getProductFromContract(product.id || '')
         } catch (e) {
             // don't need to do anything with this error necessarily,
             // it just means that the product wasn't deployed

--- a/app/src/marketplace/containers/ProductController/useProductLoadCallback.js
+++ b/app/src/marketplace/containers/ProductController/useProductLoadCallback.js
@@ -76,7 +76,7 @@ export default function useProductLoadCallback() {
             // Fetch whitelist status from contract product
             let requiresWhitelist = false
             try {
-                const contractProduct = await getProductFromContract(productId, true)
+                const contractProduct = await getProductFromContract(productId)
                 // eslint-disable-next-line prefer-destructuring
                 requiresWhitelist = contractProduct.requiresWhitelist
 

--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -25,7 +25,7 @@ const contractMethods = (usePublicNode: boolean = false) => {
 
 const parseTimestamp = (timestamp) => parseInt(timestamp, 10) * 1000
 
-export const getProductFromContract = async (id: ProductId, usePublicNode: boolean = false): SmartContractCall<SmartContractProduct> => (
+export const getProductFromContract = async (id: ProductId, usePublicNode: boolean = true): SmartContractCall<SmartContractProduct> => (
     call(contractMethods(usePublicNode).getProduct(getValidId(id)))
         .then((result) => {
             if (!result || hexEqualsZero(result.owner)) {

--- a/app/src/userpages/modules/transactionHistory/actions.js
+++ b/app/src/userpages/modules/transactionHistory/actions.js
@@ -56,7 +56,7 @@ const getTransactionsFailure = (error: ErrorInUi) => ({
 export const fetchProducts = (ids: ProductIdList) => (dispatch: Function) => {
     (ids || []).forEach((id) => {
         try {
-            getProductFromContract(id, true)
+            getProductFromContract(id)
                 .then(handleEntities(contractProductSchema, dispatch))
                 .catch((e) => {
                     console.warn(e)


### PR DESCRIPTION
Fixes an issue where after switching network, the purchase modal shows an error ([FRONT-769](https://linear.app/streamr/issue/FRONT-769/switching-network-from-purchase-modal-gives-an-error)).

Error happens because the contract product was fetching from the network selected in Metamask, not the public network. I changed it so that contract product is fetched from public chain by default.