### PR TITLE
Move loading indicator to Toolbar

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/editProductPage.pcss
+++ b/app/src/marketplace/containers/EditProductPage/editProductPage.pcss
@@ -12,13 +12,6 @@
   padding-top: 0;
 }
 
-.loadingIndicator {
-  top: 82px;
-  position: sticky;
-  width: 100%;
-  z-index: 1;
-}
-
 .toolbarMiddle {
   color: #A3A3A3;
   font-family: var(--sans);

--- a/app/src/marketplace/containers/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage/index.jsx
@@ -207,15 +207,14 @@ const EditProductPage = ({ product }: { product: Product }) => {
                     middle={toolbarMiddle}
                     actions={actions}
                     altMobileLayout
+                    loading={isLoading || (isPreview && fetchingAllStreams)}
                 />
             )}
-            loadingClassname={styles.loadingIndicator}
             contentClassname={cx({
                 [coreLayoutStyles.pad]: !isPreview,
                 [styles.editorContent]: !isPreview,
                 [styles.previewContent]: !!isPreview,
             })}
-            loading={isLoading || (isPreview && fetchingAllStreams)}
         >
             <CoreHelmet title={product.name} />
             {isPreview && (
@@ -237,9 +236,9 @@ const LoadingView = () => (
     <CoreLayout
         className={styles.layout}
         nav={false}
-        loading
         navComponent={(
             <Toolbar
+                loading
                 actions={{}}
                 altMobileLayout
             />

--- a/app/src/shared/components/Layout/Core.jsx
+++ b/app/src/shared/components/Layout/Core.jsx
@@ -4,25 +4,20 @@ import React, { type Node } from 'react'
 import cx from 'classnames'
 
 import Layout from '$shared/components/Layout'
-import LoadingIndicator from '$shared/components/LoadingIndicator'
 
 import styles from './core.pcss'
 
 type Props = {
     children?: Node,
-    loading?: boolean,
     className?: string,
-    loadingClassname?: string,
     contentClassname?: string,
     navComponent?: Node,
     nav?: Node,
 }
 
 const CoreLayout = ({
-    loading,
     children,
     className,
-    loadingClassname,
     contentClassname,
     navComponent,
     nav,
@@ -33,7 +28,6 @@ const CoreLayout = ({
         nav={nav}
     >
         {navComponent || null}
-        <LoadingIndicator loading={!!loading} className={cx(styles.loadingIndicator, loadingClassname)} />
         <div className={cx(styles.content, contentClassname)}>
             {children || null}
         </div>

--- a/app/src/shared/components/Layout/core.pcss
+++ b/app/src/shared/components/Layout/core.pcss
@@ -5,10 +5,6 @@
   color: var(--greyDark);
 }
 
-.loadingIndicator {
-  top: 2px;
-}
-
 .content {
   background-color: #F8F8F8;
   flex-grow: 1;

--- a/app/src/shared/components/Toolbar/Toolbar.stories.jsx
+++ b/app/src/shared/components/Toolbar/Toolbar.stories.jsx
@@ -67,8 +67,8 @@ story('Toolbar').addWithJSX('middle icon', () => (
     <Fragment>
         <Toolbar
             actions={toolbarActions}
-            altMobileLayout
             left={text('status text', 'status')}
+            altMobileLayout
             middle={<SvgIcon
                 name="user"
                 style={{
@@ -81,3 +81,21 @@ story('Toolbar').addWithJSX('middle icon', () => (
     </Fragment>
 ))
 
+story('Toolbar').addWithJSX('loading', () => (
+    <Fragment>
+        <Toolbar
+            actions={toolbarActions}
+            left={text('status text', 'status')}
+            loading
+            altMobileLayout
+            middle={<SvgIcon
+                name="user"
+                style={{
+                    width: '40px',
+                    height: '40px',
+                }}
+            />}
+        />
+        <Content>Lorem ipsum dolor sit emat.</Content>
+    </Fragment>
+))

--- a/app/src/shared/components/Toolbar/index.jsx
+++ b/app/src/shared/components/Toolbar/index.jsx
@@ -5,6 +5,7 @@ import styled, { css } from 'styled-components'
 import Buttons, { type ButtonActions } from '$shared/components/Buttons'
 import { MD } from '$shared/utils/styled'
 import ElevatedContainer from '$shared/components/ElevatedContainer'
+import UnstyledLoadingIndicator from '$shared/components/LoadingIndicator'
 
 const Cell = styled.div`
     align-items: center;
@@ -19,11 +20,27 @@ const Right = styled.div`
     text-align: right;
 `
 
+const Items = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 80px;
+    padding: 1.25rem 2rem;
+
+    ${Left},
+    ${Right} {
+        flex: 1;
+    }
+`
+
+const LoadingIndicator = styled(UnstyledLoadingIndicator)``
+
 type Props = {
     actions?: ButtonActions,
     altMobileLayout?: boolean,
     left?: Node,
     middle?: Node,
+    loading?: boolean,
 }
 
 const UnstyledToolbar = ({
@@ -31,52 +48,59 @@ const UnstyledToolbar = ({
     altMobileLayout,
     left,
     middle,
+    loading,
     ...props
 }: Props) => (
     <ElevatedContainer {...props} data-test-hook="Toolbar">
-        {!!(left || middle) && (
-            <Left>
-                {left}
-            </Left>
-        )}
-        {!!middle && (
-            <Middle>
-                {middle}
-            </Middle>
-        )}
-        {!!actions && (
-            <Right>
-                <Buttons actions={actions} />
-            </Right>
-        )}
+        <Items>
+            {!!(left || middle) && (
+                <Left>
+                    {left}
+                </Left>
+            )}
+            {!!middle && (
+                <Middle>
+                    {middle}
+                </Middle>
+            )}
+            {!!actions && (
+                <Right>
+                    <Buttons actions={actions} />
+                </Right>
+            )}
+        </Items>
+        <LoadingIndicator loading={!!loading} />
     </ElevatedContainer>
 )
 
 const Toolbar = styled(UnstyledToolbar)`
     background-color: white;
-    display: flex;
-    min-height: 4rem;
-    padding: 1.25rem 2rem;
     position: sticky;
     top: 0;
-    width: 100%;
     z-index: 5;
-    min-height: 80px;
-    align-items: center;
+    width: 100%;
+
+    ${LoadingIndicator} {
+        position: absolute;
+        bottom: 0;
+    }
 
     ${({ altMobileLayout }) => !!altMobileLayout && css`
         @media (max-width: ${MD - 1}px) {
             bottom: 0;
-            padding: 15px;
             position: fixed;
             top: auto;
+
+            ${LoadingIndicator} {
+                top: 0;
+                bottom: auto;
+            }
+
+            ${Items} {
+                padding: 15px;
+            }
         }
     `}
-
-    ${Left},
-    ${Right} {
-        flex: 1;
-    }
 `
 
 export default Toolbar

--- a/app/src/userpages/components/Layout/index.jsx
+++ b/app/src/userpages/components/Layout/index.jsx
@@ -5,6 +5,7 @@ import React, { Component, type Node } from 'react'
 import CoreLayout from '$shared/components/Layout/Core'
 import coreLayoutStyles from '$shared/components/Layout/core.pcss'
 import BodyClass from '$shared/components/BodyClass'
+import LoadingIndicator from '$shared/components/LoadingIndicator'
 import Header from '../Header'
 
 import './layout.pcss'
@@ -32,6 +33,7 @@ class UserpagesLayout extends Component<Props, State> {
             headerSearchComponent,
             headerFilterComponent,
             noHeader,
+            loading,
             ...props
         } = this.props
         return (
@@ -48,6 +50,7 @@ class UserpagesLayout extends Component<Props, State> {
                             filterComponent={headerFilterComponent}
                             noHeader={noHeader}
                         />
+                        <LoadingIndicator loading={!!loading} />
                     </React.Fragment>
                 )}
             />

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -3,7 +3,6 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
-import styled from 'styled-components'
 
 import { CoreHelmet } from '$shared/components/Helmet'
 import { Provider as PendingProvider } from '$shared/contexts/Pending'
@@ -14,16 +13,12 @@ import { usePending } from '$shared/hooks/usePending'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import { selectUserData } from '$shared/modules/user/selectors'
 
-import Layout from '$shared/components/Layout'
 import CoreLayout from '$shared/components/Layout/Core'
-import LoadingIndicator from '$shared/components/LoadingIndicator'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
 import routes from '$routes'
 import ProfileSettings from './ProfileSettings'
 import DeleteAccount from './DeleteAccount'
-
-import styles from './profilePage.pcss'
 
 export const ProfilePage = () => {
     const { isPending: isSavePending, wrap } = usePending('user.SAVE')
@@ -72,6 +67,7 @@ export const ProfilePage = () => {
             navComponent={(
                 <Toolbar
                     altMobileLayout
+                    loading={isLoading}
                     actions={{
                         cancel: {
                             title: 'Cancel',
@@ -88,8 +84,6 @@ export const ProfilePage = () => {
                     }}
                 />
             )}
-            loading={isLoading}
-            loadingClassname={styles.loadingIndicator}
         >
             <CoreHelmet title="Profile" />
             <TOCPage title="Settings">
@@ -108,14 +102,17 @@ export const ProfilePage = () => {
     )
 }
 
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  top: 2px;
-`
-
 const LoadingView = () => (
-    <Layout>
-        <StyledLoadingIndicator loading />
-    </Layout>
+    <CoreLayout
+        nav={false}
+        navComponent={(
+            <Toolbar
+                loading
+                actions={{}}
+                altMobileLayout
+            />
+        )}
+    />
 )
 
 const ProfileWrap = () => {

--- a/app/src/userpages/components/ProfilePage/profilePage.pcss
+++ b/app/src/userpages/components/ProfilePage/profilePage.pcss
@@ -1,6 +1,0 @@
-.loadingIndicator {
-  top: 82px;
-  position: sticky;
-  width: 100%;
-  z-index: 1;
-}

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -231,10 +231,10 @@ const UnstyledEdit = ({ disabled, isNewStream, ...props }: any) => {
         <CoreLayout
             {...props}
             nav={false}
-            loading={spinner}
             navComponent={(
                 <Toolbar
                     altMobileLayout
+                    loading={spinner}
                     left={<BackButton onBack={cancel} />}
                     actions={{
                         share: {

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -505,10 +505,10 @@ const UnstyledNew = ({ currentUser, ...props }) => {
         <Layout
             {...props}
             nav={false}
-            loading={loading}
             navComponent={(
                 <Toolbar
                     altMobileLayout
+                    loading={loading}
                     left={(
                         <BackButton onBack={onBack} />
                     )}
@@ -745,6 +745,19 @@ const New = styled(UnstyledNew)`
     }
 `
 
+const LoadingView = () => (
+    <Layout
+        nav={false}
+        navComponent={(
+            <Toolbar
+                loading
+                actions={{}}
+                altMobileLayout
+            />
+        )}
+    />
+)
+
 const NewStreamViewMaybe = (props) => {
     const currentUser = useSelector(selectUserData)
     const { state: stream, replaceState: resetStream } = useEditableState()
@@ -759,7 +772,7 @@ const NewStreamViewMaybe = (props) => {
 
     if (!currentUser || !stream) {
         return (
-            <Layout loading />
+            <LoadingView />
         )
     }
 

--- a/app/src/userpages/components/StreamPage/index.jsx
+++ b/app/src/userpages/components/StreamPage/index.jsx
@@ -19,10 +19,10 @@ const StreamPage = () => {
     if (!hasLoaded || !stream) {
         return (
             <Layout
-                loading
                 nav={false}
                 navComponent={(
                     <Toolbar
+                        loading
                         actions={{}}
                         altMobileLayout
                     />


### PR DESCRIPTION
Some pages had a custom style to make the Toolbar loading indicator sticky and some didn't. This combines that functionality into the `Toolbar` components and removes the `loading` prop from `CoreLayout`.