### PR TITLE
[FRONT-818] Brubeck stream migration

### DIFF
--- a/app/src/shared/components/TOCPage/TOCSection.jsx
+++ b/app/src/shared/components/TOCPage/TOCSection.jsx
@@ -9,6 +9,7 @@ type Props = {
     id: string,
     title?: string | Element<any>,
     status?: string | Element<any>,
+    icon?: string | Element<any>,
     children?: Node,
     onlyDesktop?: boolean,
 }
@@ -37,8 +38,9 @@ const Title = styled.h3`
 `
 
 const TitleWrapper = styled.div`
-    display: inline-flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    column-gap: 16px;
     align-items: center;
     width: 100%;
 `
@@ -51,6 +53,7 @@ export const UnstyledTOCSection = ({
     id,
     title,
     status,
+    icon,
     children,
     onlyDesktop,
     ...props
@@ -63,6 +66,7 @@ export const UnstyledTOCSection = ({
                     {!!title && (
                         <TitleText>{title}</TitleText>
                     )}
+                    {icon || <span />}
                     {!!status && (
                         <Status>{status}</Status>
                     )}

--- a/app/src/shared/flowtype/stream-types.js
+++ b/app/src/shared/flowtype/stream-types.js
@@ -32,6 +32,9 @@ export type Stream = {
     uiChannel: boolean,
     requireSignedData: boolean,
     requireEncryptedData: boolean,
+    migrateToBrubeck: boolean,
+    migrateSyncTurnedOnAt: ?string,
+    migrateSyncLastRunAt: ?string,
 }
 
 export type StreamIdList = Array<StreamId>

--- a/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
@@ -60,8 +60,8 @@ export function StatusView({ disabled, stream, updateStream }: Props) {
     return (
         <div>
             <Description>
-                This stream exists in the Corea milestone network, which will be shut down on March 31st 2022.
-                You can enable the below switch to automatically recreate the stream and its permissions in the new Brubeck network.
+                This stream exists in the Corea milestone network, which will be shut down on May 31st 2022.
+                You can enable the below switch to automatically recreate the stream and its permissions in the new Brubeck network when it launches.
                 Alternatively, you can recreate your stream and permissions manually at any time.
                 <br />
                 <br />

--- a/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
@@ -1,0 +1,89 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+
+import { MEDIUM } from '$shared/utils/styled'
+import type { Stream } from '$shared/flowtype/stream-types'
+import UnstyledToggle from '$shared/components/Toggle'
+
+type Props = {
+    disabled: boolean,
+    stream: Stream,
+    updateStream?: Function,
+}
+
+const Description = styled.p`
+    margin-bottom: 3rem;
+`
+
+const InputContainer = styled.div`
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-column-gap: 1rem;
+    background: #FFFFFF;
+    padding: 24px 36px;
+`
+
+const Label = styled.label`
+    font-weight: ${MEDIUM};
+    font-size: 16px;
+    margin-bottom: 0;
+    color: #323232;
+`
+
+const Toggle = styled(UnstyledToggle)`
+    display: flex;
+    align-items: center;
+
+    * {
+        margin-bottom: 0;
+    }
+`
+
+const LastSync = styled.div`
+    color: #323232;
+    font-size: 12px;
+    line-height: 12px;
+    margin-top: 24px;
+`
+
+export function StatusView({ disabled, stream, updateStream }: Props) {
+    const { migrateToBrubeck, migrateSyncLastRunAt } = stream || {}
+
+    return (
+        <div>
+            <Description>
+                This stream exists in the Corea milestone network, which will be shut down on March 31st 2022.
+                You can enable the below switch to automatically recreate the stream and its permissions in the new Brubeck network.
+                Alternatively, you can recreate your stream and permissions manually at any time.
+                <br />
+                <br />
+                Note that messages in the stream are not automatically copied to the new network -
+                please update your data publishers to use the new network. <a href="#">Learn more</a> about migrating to Brubeck.
+            </Description>
+            <InputContainer>
+                <Label htmlFor="migrationEnabled">
+                    Sync this stream and its permissions to Brubeck
+                </Label>
+                <Toggle
+                    disabled={disabled}
+                    id="migrationEnabled"
+                    value={migrateToBrubeck}
+                    onChange={(value) => {
+                        if (typeof updateStream !== 'function') {
+                            return
+                        }
+                        updateStream('set migrateToBrubeck flag', (s) => ({
+                            ...s,
+                            migrateToBrubeck: value,
+                        }))
+                    }}
+                />
+            </InputContainer>
+            <LastSync>Last synced on: {migrateSyncLastRunAt}</LastSync>
+        </div>
+    )
+}
+
+export default StatusView

--- a/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { MEDIUM } from '$shared/utils/styled'
 import type { Stream } from '$shared/flowtype/stream-types'
@@ -9,12 +9,18 @@ import UnstyledToggle from '$shared/components/Toggle'
 
 type Props = {
     disabled: boolean,
-    stream: Stream,
+    stream: ?Stream,
     updateStream?: Function,
 }
 
 const Description = styled.p`
     margin-bottom: 3rem;
+`
+
+const OpacityContainer = styled.div`
+    ${({ disabled }) => !!disabled && css`
+        opacity: 0.5;
+    `}
 `
 
 const InputContainer = styled.div`
@@ -62,26 +68,27 @@ export function StatusView({ disabled, stream, updateStream }: Props) {
                 Note that messages in the stream are not automatically copied to the new network -
                 please update your data publishers to use the new network. <a href="#">Learn more</a> about migrating to Brubeck.
             </Description>
-            <InputContainer>
-                <Label htmlFor="migrationEnabled">
-                    Sync this stream and its permissions to Brubeck
-                </Label>
-                <Toggle
-                    disabled={disabled}
-                    id="migrationEnabled"
-                    value={migrateToBrubeck}
-                    onChange={(value) => {
-                        if (typeof updateStream !== 'function') {
-                            return
-                        }
-                        updateStream('set migrateToBrubeck flag', (s) => ({
-                            ...s,
-                            migrateToBrubeck: value,
-                        }))
-                    }}
-                />
-            </InputContainer>
-            <LastSync>Last synced on: {migrateSyncLastRunAt}</LastSync>
+            <OpacityContainer disabled={disabled}>
+                <InputContainer>
+                    <Label htmlFor="migrationEnabled">
+                        Sync this stream and its permissions to Brubeck
+                    </Label>
+                    <Toggle
+                        disabled={disabled}
+                        id="migrationEnabled"
+                        value={migrateToBrubeck}
+                        onChange={(value) => {
+                            if (typeof updateStream !== 'function') {
+                                return
+                            }
+                            updateStream({
+                                migrateToBrubeck: value,
+                            })
+                        }}
+                    />
+                </InputContainer>
+                <LastSync>Last synced on: {migrateSyncLastRunAt || 'N/A'}</LastSync>
+            </OpacityContainer>
         </div>
     )
 }

--- a/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/MigrateView.jsx
@@ -66,7 +66,17 @@ export function StatusView({ disabled, stream, updateStream }: Props) {
                 <br />
                 <br />
                 Note that messages in the stream are not automatically copied to the new network -
-                please update your data publishers to use the new network. <a href="#">Learn more</a> about migrating to Brubeck.
+                please update your data publishers to use the new network.
+                {' '}
+                <a
+                    href="https://blog.streamr.network/mainnet-launchpad-streamr-network-approaches-key-milestone-of-decentralization/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    Learn more
+                </a>
+                {' '}
+                about migrating to Brubeck.
             </Description>
             <OpacityContainer disabled={disabled}>
                 <InputContainer>

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -32,6 +32,7 @@ import { truncate } from '$shared/utils/text'
 import routes from '$routes'
 
 import { useController } from '../../StreamController'
+import { WarningIcon } from '../shared/Icons'
 import InfoView from './InfoView'
 import MigrateView from './MigrateView'
 import ConfigureView from './ConfigureView'
@@ -287,6 +288,7 @@ const UnstyledEdit = ({ disabled, isNewStream, ...props }: any) => {
                             <TOCPage.Section
                                 id="migrate"
                                 title="Migration to Brubeck"
+                                icon={<WarningIcon />}
                             >
                                 <MigrateView
                                     stream={stream}

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -33,6 +33,7 @@ import routes from '$routes'
 
 import { useController } from '../../StreamController'
 import InfoView from './InfoView'
+import MigrateView from './MigrateView'
 import ConfigureView from './ConfigureView'
 import PreviewView from './PreviewView'
 import HistoryView from './HistoryView'
@@ -278,6 +279,16 @@ const UnstyledEdit = ({ disabled, isNewStream, ...props }: any) => {
                                 title="Details"
                             >
                                 <InfoView
+                                    stream={stream}
+                                    disabled={isDisabled}
+                                    updateStream={updateStream}
+                                />
+                            </TOCPage.Section>
+                            <TOCPage.Section
+                                id="migrate"
+                                title="Migration to Brubeck"
+                            >
+                                <MigrateView
                                     stream={stream}
                                     disabled={isDisabled}
                                     updateStream={updateStream}

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -34,9 +34,11 @@ import CodeSnippets from '$shared/components/CodeSnippets'
 import { Provider as UndoContextProvider } from '$shared/contexts/Undo'
 import useEditableState from '$shared/contexts/Undo/useEditableState'
 import routes from '$routes'
+import { WarningIcon } from './shared/Icons'
 import PartitionsView from './Edit/PartitionsView'
 import HistoryView from './Edit/HistoryView'
 import ConfigureView from './Edit/ConfigureView'
+import MigrateView from './Edit/MigrateView'
 import { StatusView } from './Edit/StatusView'
 import SecurityView from './Edit/SecurityView'
 import Preview from './Edit/PreviewView'
@@ -629,6 +631,17 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                                         />
                                     </Field>
                                 </FormGroup>
+                            </TOCSection>
+                            <TOCSection
+                                id="migrate"
+                                title="Migration to Brubeck"
+                                icon={<WarningIcon />}
+                                disabled
+                            >
+                                <MigrateView
+                                    disabled
+                                    updateStream={updateStream}
+                                />
                             </TOCSection>
                             <TOCSection
                                 id="snippets"

--- a/app/src/userpages/components/StreamPage/shared/Icons.jsx
+++ b/app/src/userpages/components/StreamPage/shared/Icons.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export const WarningIcon = () => (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 20c5.523 0 10-4.477 10-10S15.523 0 10 0 0 4.477 0 10s4.477 10 10 10Z" fill="#FF5C00" />
+        <path d="M10 11.562V5" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M10 14.562v-.052" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+)


### PR DESCRIPTION
Adds a toggle to mark stream enabled for Brubeck migration.

Still needs a correct **Learn more** link once the blog post is published.