### PR TITLE
[FRONT-847] Replace getAllStreams with searchStreams

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/usePublish.js
+++ b/app/src/marketplace/containers/EditProductPage/usePublish.js
@@ -130,7 +130,9 @@ export default function usePublish() {
                     try {
                         // Get all streams and verify that the added streams actually exist,
                         // otherwise the product update will fail
-                        const gen = await client.getAllStreams()
+                        const gen = client.searchStreams(undefined, {
+                            user: await client.getAddress(),
+                        })
                         const streams = []
 
                         // eslint-disable-next-line no-restricted-syntax

--- a/app/src/marketplace/containers/ProductController/useLoadAllStreamsCallback.js
+++ b/app/src/marketplace/containers/ProductController/useLoadAllStreamsCallback.js
@@ -14,7 +14,9 @@ export default function useLoadAllStreamsCallback({ setAllStreams }: {
     return useCallback(async () => (
         wrap(async () => {
             try {
-                const gen = await client.getAllStreams()
+                const gen = client.searchStreams(undefined, {
+                    user: await client.getAddress(),
+                })
                 const streams = []
 
                 // eslint-disable-next-line no-restricted-syntax

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -208,9 +208,9 @@ const StreamList = () => {
 
             const nextStreams = []
 
-            const gen = params.search
-                ? client.searchStreams(params.search)
-                : client.getAllStreams()
+            const gen = client.searchStreams(params.search, {
+                user: await client.getAddress(),
+            })
 
             // eslint-disable-next-line no-restricted-syntax
             for await (const stream of gen) {


### PR DESCRIPTION
Client's `getAllStreams` was actually getting *all* streams regardless of user. Replaced those calls with `searchStreams` that has a `user` filter.