### PR TITLE
FRONT-845: Storage node checkboxes fixed

### DIFF
--- a/app/src/userpages/components/StreamPage/shared/Storage.jsx
+++ b/app/src/userpages/components/StreamPage/shared/Storage.jsx
@@ -46,7 +46,7 @@ const UnstyledStorage = ({ stream, disabled, ...props }) => {
                         address={address}
                         name={name}
                         changing={addresses == null}
-                        checked={(addresses || []).includes(address)}
+                        checked={(addresses || []).includes(address.toLowerCase())}
                         disabled={disabled}
                         key={address}
                         stream={stream}

--- a/app/src/userpages/components/StreamPage/shared/useStreamStorageNodeAddresses.js
+++ b/app/src/userpages/components/StreamPage/shared/useStreamStorageNodeAddresses.js
@@ -17,7 +17,7 @@ const useStreamStorageNodeAddresses = (stream) => {
             }
 
             if (isMounted()) {
-                setNodes(result.map(({ storageNodeAddress: address }) => address))
+                setNodes(result.map((address) => address.toLowerCase()))
             }
         }
 


### PR DESCRIPTION
`getStorageNodes` is now more down-to-earth and simply returns an array of addresses. I also make any comparisons case insensitive.