### PR TITLE
FRONT-813: Fix falsely unsaved stream edits

### DIFF
--- a/app/src/userpages/components/StreamPage/Edit/StatusView.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/StatusView.jsx
@@ -37,7 +37,7 @@ const InputContainer = styled.div`
 `
 
 export function StatusView({ disabled, stream, updateStream }: Props) {
-    const { inactivityThresholdHours } = stream || {}
+    const { inactivityThresholdHours = 0 } = stream || {}
 
     // init units based on initial threshold value
     // don't calculate on the fly otherwise


### PR DESCRIPTION
Smashing it the simplest way possible. `inactivityThresholdHours` is `NaN` by default. Weird but hey.