### PR TITLE
FRONT-874: Logout fix

### DIFF
--- a/app/src/analytics.js
+++ b/app/src/analytics.js
@@ -108,7 +108,7 @@ if (process.env.SENTRY_DSN) {
 
 // empty the request body for these paths
 const urlBlackList = [
-    '/api/v1/login/password',
+    '/api/v2/login/password',
 ]
 
 if (process.env.LOGROCKET_SLUG) {

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -1,8 +1,8 @@
 {
     "auth": {
         "external": {
-            "login": "<streamr>/api/v1/login/response",
-            "logout": "<streamr>/api/v1/logout"
+            "login": "<api>/login/response",
+            "logout": "<api>/logout"
         },
         "login": "/login",
         "logout": "/logout"

--- a/app/src/shared/hooks/useScrollToTop.js
+++ b/app/src/shared/hooks/useScrollToTop.js
@@ -7,7 +7,7 @@ export const scrollTop = () => {
     }
 }
 
-export default () => {
+export default function useScrollToTop() {
     const { pathname } = useLocation()
 
     useEffect(() => {

--- a/app/src/shared/test/modules/user/services.test.js
+++ b/app/src/shared/test/modules/user/services.test.js
@@ -47,7 +47,7 @@ describe('user - services', () => {
                 })
 
                 expect(request.config.method).toBe('get')
-                expect(request.config.url).toBe('http://localhost/api/v1/users/me?noCache=1337')
+                expect(request.config.url).toBe('http://localhost/api/v2/users/me?noCache=1337')
             })
 
             const result = await services.getUserData()
@@ -71,7 +71,7 @@ describe('user - services', () => {
                 })
 
                 expect(request.config.method).toBe('put')
-                expect(request.config.url).toBe('http://localhost/api/v1/users/me')
+                expect(request.config.url).toBe('http://localhost/api/v2/users/me')
                 expect(request.headers['Content-Type']).toBe('application/json')
             })
 
@@ -89,7 +89,7 @@ describe('user - services', () => {
                 })
 
                 expect(request.config.method).toBe('delete')
-                expect(request.config.url).toBe('http://localhost/api/v1/users/me')
+                expect(request.config.url).toBe('http://localhost/api/v2/users/me')
             })
 
             await services.deleteUserAccount()
@@ -118,7 +118,7 @@ describe('user - services', () => {
                 })
 
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe('http://localhost/api/v1/users/me/image')
+                expect(request.config.url).toBe('http://localhost/api/v2/users/me/image')
                 expect(request.headers['Content-Type']).toBe('multipart/form-data')
             })
 
@@ -144,7 +144,7 @@ describe('user - services', () => {
                 })
 
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe(`http://localhost/api/v1/login/challenge/${account}`)
+                expect(request.config.url).toBe(`http://localhost/api/v2/login/challenge/${account}`)
                 expect(request.headers['Content-Type']).toBe('application/x-www-form-urlencoded')
             })
 

--- a/app/test/unit/modules/categories/services.test.js
+++ b/app/test/unit/modules/categories/services.test.js
@@ -38,7 +38,7 @@ describe('categories - services', () => {
             })
 
             expect(request.config.method).toBe('get')
-            expect(request.config.url).toBe('http://localhost/api/v1/categories?includeEmpty=true')
+            expect(request.config.url).toBe('http://localhost/api/v2/categories?includeEmpty=true')
             done()
         })
 
@@ -66,7 +66,7 @@ describe('categories - services', () => {
             })
 
             expect(request.config.method).toBe('get')
-            expect(request.config.url).toBe('http://localhost/api/v1/categories?includeEmpty=false')
+            expect(request.config.url).toBe('http://localhost/api/v2/categories?includeEmpty=false')
             done()
         })
 

--- a/app/test/unit/modules/myProductList/services.test.js
+++ b/app/test/unit/modules/myProductList/services.test.js
@@ -61,7 +61,7 @@ describe('myProductList - services', () => {
             })
 
             expect(request.config.method).toBe('get')
-            expect(request.config.url).toBe('http://localhost/api/v1/users/me/products')
+            expect(request.config.url).toBe('http://localhost/api/v2/users/me/products')
         })
 
         const result = await getMyProducts()

--- a/app/test/unit/modules/myPurchaseList/services.test.js
+++ b/app/test/unit/modules/myPurchaseList/services.test.js
@@ -65,7 +65,7 @@ describe('myPurchaseList - services', () => {
                 response: data,
             })
             expect(request.config.method).toBe('get')
-            expect(request.config.url).toBe('http://localhost/api/v1/subscriptions')
+            expect(request.config.url).toBe('http://localhost/api/v2/subscriptions')
         })
         const result = await services.getMyPurchases()
         expect(result).toStrictEqual(expectedResult)

--- a/app/test/unit/modules/product/services.test.js
+++ b/app/test/unit/modules/product/services.test.js
@@ -70,7 +70,7 @@ describe('product - services', () => {
                 })
 
                 expect(request.config.method).toBe('get')
-                expect(request.config.url).toBe('http://localhost/api/v1/products/123')
+                expect(request.config.url).toBe('http://localhost/api/v2/products/123')
             })
 
             const result = await all.getProductById('123')
@@ -153,7 +153,7 @@ describe('product - services', () => {
             })
 
             expect(request.config.method).toBe('put')
-            expect(request.config.url).toBe(`http://localhost/api/v1/products/${data.id}`)
+            expect(request.config.url).toBe(`http://localhost/api/v2/products/${data.id}`)
         })
         const result = await all.putProduct(data, data.id)
         expect(result).toStrictEqual(expectedResult)
@@ -172,7 +172,7 @@ describe('product - services', () => {
             })
 
             expect(request.config.method).toBe('post')
-            expect(request.config.url).toBe('http://localhost/api/v1/products')
+            expect(request.config.url).toBe('http://localhost/api/v2/products')
         })
         const result = await all.postProduct(data)
         expect(result).toStrictEqual(expectedResult)
@@ -191,7 +191,7 @@ describe('product - services', () => {
             })
 
             expect(request.config.method).toBe('post')
-            expect(request.config.url).toBe(`http://localhost/api/v1/products/${data.id}/images`)
+            expect(request.config.url).toBe(`http://localhost/api/v2/products/${data.id}/images`)
         })
         const result = await all.postImage(data.id, mockFile)
         expect(result).toStrictEqual(expectedResult)
@@ -214,7 +214,7 @@ describe('product - services', () => {
                 })
 
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe(`http://localhost/api/v1/products/${productId}/undeployFree`)
+                expect(request.config.url).toBe(`http://localhost/api/v2/products/${productId}/undeployFree`)
             })
 
             const result = await all.postUndeployFree(productId)
@@ -240,7 +240,7 @@ describe('product - services', () => {
                 })
 
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe(`http://localhost/api/v1/products/${productId}/setUndeploying`)
+                expect(request.config.url).toBe(`http://localhost/api/v2/products/${productId}/setUndeploying`)
                 expect(request.config.data).toBe(JSON.stringify({
                     transactionHash: txHash,
                 }))
@@ -268,7 +268,7 @@ describe('product - services', () => {
                 })
 
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe(`http://localhost/api/v1/products/${productId}/deployFree`)
+                expect(request.config.url).toBe(`http://localhost/api/v2/products/${productId}/deployFree`)
             })
 
             const result = await all.postDeployFree(productId)
@@ -294,7 +294,7 @@ describe('product - services', () => {
                 })
 
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe(`http://localhost/api/v1/products/${productId}/setDeploying`)
+                expect(request.config.url).toBe(`http://localhost/api/v2/products/${productId}/setDeploying`)
                 expect(request.config.data).toBe(JSON.stringify({
                     transactionHash: txHash,
                 }))
@@ -318,7 +318,7 @@ describe('product - services', () => {
                     response: null,
                 })
                 expect(request.config.method).toBe('post')
-                expect(request.config.url).toBe('http://localhost/api/v1/subscriptions')
+                expect(request.config.url).toBe('http://localhost/api/v2/subscriptions')
                 expect(request.config.data).toBe(JSON.stringify({
                     product: productId,
                     endsAt,

--- a/app/test/unit/modules/productList/services.test.js
+++ b/app/test/unit/modules/productList/services.test.js
@@ -68,7 +68,7 @@ describe('productList - services', () => {
                 status: 200,
                 response: data,
             })
-            const expectedUrl = `http://localhost/api/v1\
+            const expectedUrl = `http://localhost/api/v2\
 /products?categories&grantedAccess=false&max=${productListPageSize + 1}&maxPrice&offset=0&publicAccess=true&search=&sortBy`
             expect(request.config.method).toBe('get')
             expect(request.config.url).toBe(`${expectedUrl}`)

--- a/app/test/unit/modules/relatedProducts/services.test.js
+++ b/app/test/unit/modules/relatedProducts/services.test.js
@@ -53,7 +53,7 @@ describe('relatedProducts - services', () => {
             })
 
             expect(request.config.method).toBe('get')
-            expect(request.config.url).toBe(`http://localhost/api/v1/products/${productId}/related`)
+            expect(request.config.url).toBe(`http://localhost/api/v2/products/${productId}/related`)
         })
 
         const result = await services.getRelatedProducts(productId)

--- a/app/travis_scripts/e2e-tests.sh
+++ b/app/travis_scripts/e2e-tests.sh
@@ -11,7 +11,7 @@ npx wait-on http://localhost:3333
 $(dirname $0)/start-docker-env.sh
 
 # Wait for e&e
-npx wait-on http-get://localhost/api/v1/categories
+npx wait-on http-get://localhost/api/v2/categories
 
 npm run cypress
 


### PR DESCRIPTION
The bug was… incorrect URL of the logout API endpoint. `v1` (old) vs `v2` (new).

I also took a minut and grepped for all v-ones, and changed them to `v2`.