### PR TITLE
Separate styled and unstyled $ui/Label

### DIFF
--- a/app/src/shared/components/Ui/Label.jsx
+++ b/app/src/shared/components/Ui/Label.jsx
@@ -1,10 +1,9 @@
-// @flow
-
 import styled from 'styled-components'
 import * as Colors from '$ui/StateColors'
 import { MEDIUM } from '$shared/utils/styled'
+import UnstyledLabel from '$ui/Label.unstyled'
 
-const Label = styled.label`
+const Label = styled(UnstyledLabel)`
     color: ${({ state }) => Colors[state] || Colors.DEFAULT};
     display: block;
     font-size: 12px;

--- a/app/src/shared/components/Ui/Label.unstyled.jsx
+++ b/app/src/shared/components/Ui/Label.unstyled.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Label({ className, children }) {
+    return (
+        <label className={className}>
+            {children}&zwnj;
+        </label>
+    )
+}

--- a/app/src/shared/test/components/KeyField/KeyField.test.jsx
+++ b/app/src/shared/test/components/KeyField/KeyField.test.jsx
@@ -12,7 +12,7 @@ describe('KeyField', () => {
                 value="testValue"
             />)
 
-            expect(el.find('Label').text().replace(/\u200c/g, '')).toBe('myKey') // get rid of invisible &zwnj;
+            expect(el.find('label').text().replace(/\u200c/g, '')).toBe('myKey') // get rid of invisible &zwnj;
             expect(el.find(Text).prop('value')).toBe('testValue')
             expect(el.find(Text).prop('type')).toBe('text')
         })

--- a/app/src/shared/test/components/KeyField/KeyFieldEditor/KeyFieldEditor.test.jsx
+++ b/app/src/shared/test/components/KeyField/KeyFieldEditor/KeyFieldEditor.test.jsx
@@ -14,8 +14,8 @@ describe('KeyFieldEditor', () => {
             expect(el.find('#keyName').hostNodes()).toHaveLength(1)
             expect(el.exists('#keyValue')).toBe(true)
             expect(el.find('#keyValue').hostNodes()).toHaveLength(1)
-            expect(el.find('Label').at(0).text()).toBe('Key name')
-            expect(el.find('Label').at(1).text()).toBe('API key')
+            expect(el.find('label').at(0).text()).toMatch(/Key name/)
+            expect(el.find('label').at(1).text()).toMatch(/API key/)
         })
 
         it('shows correct text for save button', () => {
@@ -70,7 +70,7 @@ describe('KeyFieldEditor', () => {
             />)
 
             expect(el.find('Text').length).toBe(1)
-            expect(el.find('Label').text()).toBe('Key name')
+            expect(el.find('label').text()).toMatch(/Key name/)
         })
 
         it('shows correct text for save button', () => {

--- a/app/src/userpages/components/StreamPage/shared/FormGroup.jsx
+++ b/app/src/userpages/components/StreamPage/shared/FormGroup.jsx
@@ -24,7 +24,7 @@ const UnstyledField = ({
     ...props
 }) => (
     <div {...props}>
-        <Label>{label}&zwnj;</Label>
+        <Label>{label}</Label>
         {children}
     </div>
 )


### PR DESCRIPTION
I’m trying something new.

- There's `$ui/Label` which is just the logic of a regular `Label`, and
- there's `$ui/Label.styled` which is a styled version of `Label` with no logic side effects.

Is this something we can try out? I'd like to see how it work on a wider range of components, over time. Best case scenario - we like it. Worst, we merge them back in.

@tumppi, I'm eager to hear your opinion!