### PR TITLE
[FRONT-1140] Stream stats

### DIFF
--- a/app/src/config/development.toml
+++ b/app/src/config/development.toml
@@ -14,7 +14,7 @@ theGraphUrl = ":8000"
 mainnetInfuraUrl = "https://mainnet.infura.io/v3/17c3985baecb4c4d94a1edc2c4d23206"
 dataUnionJoinServerUrl = "http://localhost:5555"
 theHubGraphName = "subgraphs/name/streamr-dev/hub-subgraph"
-streamIndexerUrl = "http://localhost:4001/api"
+streamIndexerUrl = ":4001/api"
 
 [[core.marketplaceContractCreationBlocks]]
 chainId = 8995

--- a/app/src/config/development.toml
+++ b/app/src/config/development.toml
@@ -14,6 +14,7 @@ theGraphUrl = ":8000"
 mainnetInfuraUrl = "https://mainnet.infura.io/v3/17c3985baecb4c4d94a1edc2c4d23206"
 dataUnionJoinServerUrl = "http://localhost:5555"
 theHubGraphName = "subgraphs/name/streamr-dev/hub-subgraph"
+streamIndexerUrl = "http://localhost:4001/api"
 
 [[core.marketplaceContractCreationBlocks]]
 chainId = 8995

--- a/app/src/getters/getCoreConfig.ts
+++ b/app/src/getters/getCoreConfig.ts
@@ -8,5 +8,6 @@ export default function getCoreConfig() {
         platformOriginUrl: formatConfigUrl(core?.platformOriginUrl),
         streamrUrl: formatConfigUrl(core?.streamrUrl),
         theGraphUrl: formatConfigUrl(core?.theGraphUrl),
+        streamIndexerUrl: formatConfigUrl(core?.streamIndexerUrl),
     }
 }

--- a/app/src/marketplace/containers/EditProductPage/StreamSelector.tsx
+++ b/app/src/marketplace/containers/EditProductPage/StreamSelector.tsx
@@ -30,20 +30,8 @@ const Heading = styled.div`
 
 const Title = styled.div`
   font-size: 34px;
-  line-height: 34px;
+  line-height: 48px;
   color: black;
-`
-
-const Stat = styled.div`
-  color: ${COLORS.primaryLight};
-  background-color: ${COLORS.secondary};
-  font-size: 18px;
-  line-height: 16px;
-  padding: 16px;
-
-  strong {
-    font-weight: ${MEDIUM};
-  }
 `
 
 export const StreamSelector: FunctionComponent = () => {
@@ -88,8 +76,6 @@ export const StreamSelector: FunctionComponent = () => {
     return <div>
         <Heading>
             <Title>Add Streams</Title>
-            <Stat>Streams <strong>{streams.length}</strong></Stat>
-            <Stat>Msg/s <strong>100</strong></Stat>
         </Heading>
         <SearchBar
             placeholder={'Search stream'}

--- a/app/src/marketplace/containers/EditProductPage/StreamSelector.tsx
+++ b/app/src/marketplace/containers/EditProductPage/StreamSelector.tsx
@@ -1,11 +1,9 @@
 import React, { FunctionComponent, useCallback, useContext, useEffect, useState } from 'react'
-import { Stream } from 'streamr-client'
 import styled from 'styled-components'
 import InterruptionError from '$shared/errors/InterruptionError'
 import useInterrupt from '$shared/hooks/useInterrupt'
-import useFetchStreams from '$shared/hooks/useFetchStreams'
-import StreamTable from '$shared/components/StreamTable'
-import { StreamId } from '$shared/types/stream-types'
+import useFetchStreamsFromIndexer from '$app/src/shared/hooks/useFetchStreamsFromIndexer'
+import { IndexerStream } from '$app/src/services/streams'
 import { ProjectStateContext } from '$mp/contexts/ProjectStateContext'
 import { useEditableProjectActions } from '$mp/containers/ProductController/useEditableProjectActions'
 import { StreamSelectTable } from '$shared/components/StreamSelectTable'
@@ -53,8 +51,8 @@ export const StreamSelector: FunctionComponent = () => {
     const {updateStreams} = useEditableProjectActions()
     const [search, setSearch] = useState<string>('')
     const itp = useInterrupt()
-    const fetchStreams = useFetchStreams()
-    const [streams, setStreams] = useState<Array<Stream>>([])
+    const fetchStreams = useFetchStreamsFromIndexer()
+    const [streams, setStreams] = useState<Array<IndexerStream>>([])
     const [hasMore, setHasMore] = useState<boolean>(false)
     const fetch = useCallback(async () => {
         const { requireUninterrupted } = itp(search)

--- a/app/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionList.tsx
+++ b/app/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionList.tsx
@@ -37,12 +37,12 @@ const PermissionList: React.FunctionComponent<Props> = ({ disabled }) => {
     const { changeset, combinations } = usePermissionsState()
     const persist = usePersistChangeset()
     const permissions = useMemo(() => (
-        Object.entries({ ...combinations, ...changeset })
+        Object.entries({ ...combinations, ...changeset }).filter((p) => p[0] !== address0)
     ), [combinations, changeset])
 
     return (
         <Container>
-            {permissions.filter((p) => p[0] && p[0] !== address0).map(([key, value]) => (
+            {permissions.map(([key, value]) => (
                 <PermissionItem
                     key={key}
                     address={key}
@@ -52,7 +52,7 @@ const PermissionList: React.FunctionComponent<Props> = ({ disabled }) => {
             ))}
             <Footer>
                 <span>
-                    {permissions.length} Ethereum account{permissions.length > 1 ? 's' : ''}
+                    {permissions.length} Ethereum account{permissions.length === 1 ? '' : 's'}
                 </span>
                 <Button
                     kind="primary"

--- a/app/src/pages/NewStreamListingPage/index.tsx
+++ b/app/src/pages/NewStreamListingPage/index.tsx
@@ -11,6 +11,7 @@ import SearchBar from '$shared/components/SearchBar'
 import Tabs from '$shared/components/Tabs'
 import useInterrupt from '$shared/hooks/useInterrupt'
 import useFetchStreams from '$shared/hooks/useFetchStreams'
+import useFetchStreamsFromIndexer from '$shared/hooks/useFetchStreamsFromIndexer'
 import InterruptionError from '$shared/errors/InterruptionError'
 import { isAuthenticated } from '$shared/modules/user/selectors'
 import { FiltersBar, FiltersWrap, SearchBarWrap } from '$mp/components/ActionBar/actionBar.styles'
@@ -65,7 +66,7 @@ const NewStreamListingPage: React.FC = () => {
     const isUserAuthenticated = useSelector(isAuthenticated)
 
     const itp = useInterrupt()
-    const fetchStreams = useFetchStreams()
+    const fetchStreams = useFetchStreamsFromIndexer()
 
     const fetch = useCallback(async () => {
         const { requireUninterrupted } = itp(search)

--- a/app/src/pages/NewStreamListingPage/index.tsx
+++ b/app/src/pages/NewStreamListingPage/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import type { Stream } from 'streamr-client'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
@@ -10,7 +9,6 @@ import Layout from '$shared/components/Layout'
 import SearchBar from '$shared/components/SearchBar'
 import Tabs from '$shared/components/Tabs'
 import useInterrupt from '$shared/hooks/useInterrupt'
-import useFetchStreams from '$shared/hooks/useFetchStreams'
 import useFetchStreamsFromIndexer from '$shared/hooks/useFetchStreamsFromIndexer'
 import { IndexerStream } from '$app/src/services/streams'
 import InterruptionError from '$shared/errors/InterruptionError'
@@ -38,7 +36,7 @@ const streamSelectionOptions = (isUserAuthenticated: boolean) => [
     },
 ]
 
-const PAGE_SIZE = 1
+const PAGE_SIZE = 10
 
 const Container = styled.div`
     background-color: ${COLORS.secondary};
@@ -130,6 +128,7 @@ const NewStreamListingPage: React.FC = () => {
                         streams={streams}
                         loadMore={fetch}
                         hasMoreResults={hasMore}
+                        showGlobalStats={streamsSelection === StreamSelection.ALL}
                     />
                 </TableContainer>
             </Container>

--- a/app/src/pages/NewStreamListingPage/index.tsx
+++ b/app/src/pages/NewStreamListingPage/index.tsx
@@ -36,7 +36,7 @@ const streamSelectionOptions = (isUserAuthenticated: boolean) => [
     },
 ]
 
-const BATCH_SIZE = 10
+const BATCH_SIZE = 1
 
 const Container = styled.div`
     background-color: ${COLORS.secondary};

--- a/app/src/pages/NewStreamListingPage/index.tsx
+++ b/app/src/pages/NewStreamListingPage/index.tsx
@@ -12,6 +12,7 @@ import Tabs from '$shared/components/Tabs'
 import useInterrupt from '$shared/hooks/useInterrupt'
 import useFetchStreams from '$shared/hooks/useFetchStreams'
 import useFetchStreamsFromIndexer from '$shared/hooks/useFetchStreamsFromIndexer'
+import { IndexerStream } from '$app/src/services/streams'
 import InterruptionError from '$shared/errors/InterruptionError'
 import { isAuthenticated } from '$shared/modules/user/selectors'
 import { FiltersBar, FiltersWrap, SearchBarWrap } from '$mp/components/ActionBar/actionBar.styles'
@@ -37,7 +38,7 @@ const streamSelectionOptions = (isUserAuthenticated: boolean) => [
     },
 ]
 
-const BATCH_SIZE = 1
+const PAGE_SIZE = 1
 
 const Container = styled.div`
     background-color: ${COLORS.secondary};
@@ -61,7 +62,7 @@ const TableContainer = styled.div`
 const NewStreamListingPage: React.FC = () => {
     const [search, setSearch] = useState<string>('')
     const [streamsSelection, setStreamsSelection] = useState<StreamSelection>(StreamSelection.ALL)
-    const [streams, setStreams] = useState<Array<Stream>>([])
+    const [streams, setStreams] = useState<Array<IndexerStream>>([])
     const [hasMore, setHasMore] = useState<boolean>(false)
     const isUserAuthenticated = useSelector(isAuthenticated)
 
@@ -74,7 +75,7 @@ const NewStreamListingPage: React.FC = () => {
         try {
             const allowPublic = streamsSelection === StreamSelection.ALL
             const [newStreams, hasMoreResults, isFirstBatch] = await fetchStreams(search, {
-                batchSize: BATCH_SIZE,
+                batchSize: PAGE_SIZE,
                 allowPublic,
                 onlyCurrentUser: streamsSelection === StreamSelection.YOUR,
             })

--- a/app/src/services/streams.ts
+++ b/app/src/services/streams.ts
@@ -50,3 +50,29 @@ export const getStreamsFromIndexer = async (first: number, cursor?: string, owne
 
     return result.data.streams
 }
+
+export type GlobalStreamStats = {
+    streamCount: number,
+    messagesPerSecond: number,
+}
+
+export const getGlobalStatsFromIndexer = async (): Promise<GlobalStreamStats> => {
+    const { streamIndexerUrl } = getCoreConfig()
+
+    const result = await post({
+        url: streamIndexerUrl,
+        data: {
+            query: `
+                {
+                    summary {
+                        streamCount
+                        messagesPerSecond
+                    }
+                }
+            `,
+        },
+        useAuthorization: false,
+    })
+
+    return result.data.summary
+}

--- a/app/src/shared/components/StreamSelectTable/index.tsx
+++ b/app/src/shared/components/StreamSelectTable/index.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
-import type { Stream } from 'streamr-client'
+import React, { FunctionComponent, useCallback, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import LoadMore from '$mp/components/LoadMore'
 import { StreamId } from '$shared/types/stream-types'
 import { COLORS, MEDIUM, REGULAR, DESKTOP, TABLET } from '$shared/utils/styled'
 import Checkbox from '$shared/components/Checkbox'
+import { IndexerStream } from '$app/src/services/streams'
 import routes from '$routes'
 
 const ROW_HEIGHT = 88
@@ -152,7 +152,7 @@ const StreamDescription = styled(GridCell)`
 `
 
 type Props = {
-    streams: Array<Stream>,
+    streams: Array<IndexerStream>,
     loadMore?: () => void | Promise<void>,
     hasMoreResults?: boolean,
     onSelectionChange: (selectedStreams: StreamId[]) => void
@@ -241,15 +241,15 @@ export const StreamSelectTable: FunctionComponent<Props> = ({
                                 </StreamId>
                                 {'\n'}
                                 <StreamDescription notOnTablet>
-                                    {s.getMetadata().description}
+                                    {s.description}
                                 </StreamDescription>
                             </StreamDetails>
-                            <GridCell onlyTablet>{s.getMetadata().description}</GridCell>
-                            <GridCell onlyDesktop>50</GridCell>
-                            <GridCell onlyDesktop>1</GridCell>
-                            <GridCell onlyDesktop>Public</GridCell>
-                            <GridCell onlyDesktop>5</GridCell>
-                            <GridCell onlyDesktop>100</GridCell>
+                            <GridCell onlyTablet>{s.description}</GridCell>
+                            <GridCell onlyDesktop>{s.peerCount}</GridCell>
+                            <GridCell onlyDesktop>{s.messagesPerSecond}</GridCell>
+                            <GridCell onlyDesktop>{s.subscriberCount == null ? 'Public' : 'Private'}</GridCell>
+                            <GridCell onlyDesktop>{s.publisherCount}</GridCell>
+                            <GridCell onlyDesktop>{s.subscriberCount}</GridCell>
                             <GridCell flex={true}>
                                 <Checkbox value={selectedStreams[s.id]} onChange={() => {
                                     handleSelectChange(s.id)

--- a/app/src/shared/components/StreamSelectTable/index.tsx
+++ b/app/src/shared/components/StreamSelectTable/index.tsx
@@ -18,14 +18,14 @@ const Row = styled.div`
 const TableGrid = styled(Row)`
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) 18px;
 
   @media ${TABLET} {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 18px;
   }
 
   @media ${DESKTOP} {
-    grid-template-columns: minmax(0, 3fr) repeat(6, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 3fr) repeat(5, minmax(0, 1fr)) 18px;
   }
 `
 
@@ -248,8 +248,8 @@ export const StreamSelectTable: FunctionComponent<Props> = ({
                             <GridCell onlyDesktop>{s.peerCount}</GridCell>
                             <GridCell onlyDesktop>{s.messagesPerSecond}</GridCell>
                             <GridCell onlyDesktop>{s.subscriberCount == null ? 'Public' : 'Private'}</GridCell>
-                            <GridCell onlyDesktop>{s.publisherCount}</GridCell>
-                            <GridCell onlyDesktop>{s.subscriberCount}</GridCell>
+                            <GridCell onlyDesktop>{s.publisherCount || '-'}</GridCell>
+                            <GridCell onlyDesktop>{s.subscriberCount || '-'}</GridCell>
                             <GridCell flex={true}>
                                 <Checkbox value={selectedStreams[s.id]} onChange={() => {
                                     handleSelectChange(s.id)

--- a/app/src/shared/components/StreamTable/index.tsx
+++ b/app/src/shared/components/StreamTable/index.tsx
@@ -5,8 +5,8 @@ import { Link } from 'react-router-dom'
 
 import LoadMore from '$mp/components/LoadMore'
 import { COLORS, MEDIUM, REGULAR, DESKTOP, TABLET } from '$shared/utils/styled'
+import { useStreamStats } from '$shared/hooks/useStreamStats'
 import routes from '$routes'
-import { useStreamStats } from '../../hooks/useStreamStats'
 
 const ROW_HEIGHT = 88
 

--- a/app/src/shared/components/StreamTable/index.tsx
+++ b/app/src/shared/components/StreamTable/index.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom'
 
 import LoadMore from '$mp/components/LoadMore'
 import { COLORS, MEDIUM, REGULAR, DESKTOP, TABLET } from '$shared/utils/styled'
-import { useStreamStats } from '$shared/hooks/useStreamStats'
+import { IndexerStream } from '$app/src/services/streams'
 import routes from '$routes'
 
 const ROW_HEIGHT = 88
@@ -196,15 +196,12 @@ const Stat = styled.div`
 
 type Props = {
     title?: string,
-    streams: Array<Stream>,
+    streams: Array<IndexerStream>,
     loadMore?: () => void | Promise<void>,
     hasMoreResults?: boolean,
 }
 
 const StreamTable: React.FC<Props> = ({ title = "Streams", streams, loadMore, hasMoreResults }: Props) => {
-    const stats = useStreamStats(streams)
-    console.log(stats)
-
     return (
         <Container>
             <Heading>
@@ -231,15 +228,15 @@ const StreamTable: React.FC<Props> = ({ title = "Streams", streams, loadMore, ha
                                 </StreamId>
                                 {'\n'}
                                 <StreamDescription notOnTablet>
-                                    {s.getMetadata().description}
+                                    {s.description}
                                 </StreamDescription>
                             </StreamDetails>
-                            <GridCell onlyTablet>{s.getMetadata().description}</GridCell>
-                            <GridCell onlyDesktop>50</GridCell>
-                            <GridCell onlyDesktop>1</GridCell>
+                            <GridCell onlyTablet>{s.description}</GridCell>
+                            <GridCell onlyDesktop>{s.peerCount}</GridCell>
+                            <GridCell onlyDesktop>{s.messagesPerSecond}</GridCell>
                             <GridCell onlyDesktop>Public</GridCell>
-                            <GridCell onlyDesktop>5</GridCell>
-                            <GridCell onlyDesktop>100</GridCell>
+                            <GridCell onlyDesktop>{s.publisherCount}</GridCell>
+                            <GridCell onlyDesktop>{s.subscriberCount}</GridCell>
                         </TableRow>
                     ))}
                     {streams.length === 0 && <NoStreams>No streams that match your query</NoStreams>}

--- a/app/src/shared/components/StreamTable/index.tsx
+++ b/app/src/shared/components/StreamTable/index.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import LoadMore from '$mp/components/LoadMore'
 import { COLORS, MEDIUM, REGULAR, DESKTOP, TABLET } from '$shared/utils/styled'
 import routes from '$routes'
+import { useStreamStats } from '../../hooks/useStreamStats'
 
 const ROW_HEIGHT = 88
 
@@ -201,6 +202,9 @@ type Props = {
 }
 
 const StreamTable: React.FC<Props> = ({ title = "Streams", streams, loadMore, hasMoreResults }: Props) => {
+    const stats = useStreamStats(streams)
+    console.log(stats)
+
     return (
         <Container>
             <Heading>

--- a/app/src/shared/components/StreamTable/index.tsx
+++ b/app/src/shared/components/StreamTable/index.tsx
@@ -234,7 +234,7 @@ const StreamTable: React.FC<Props> = ({ title = "Streams", streams, loadMore, ha
                             <GridCell onlyTablet>{s.description}</GridCell>
                             <GridCell onlyDesktop>{s.peerCount}</GridCell>
                             <GridCell onlyDesktop>{s.messagesPerSecond}</GridCell>
-                            <GridCell onlyDesktop>Public</GridCell>
+                            <GridCell onlyDesktop>{s.subscriberCount == null ? 'Public' : 'Private'}</GridCell>
                             <GridCell onlyDesktop>{s.publisherCount}</GridCell>
                             <GridCell onlyDesktop>{s.subscriberCount}</GridCell>
                         </TableRow>

--- a/app/src/shared/components/Tile/index.tsx
+++ b/app/src/shared/components/Tile/index.tsx
@@ -324,7 +324,7 @@ const MarketplaceProductTile = ({ product, showDataUnionBadge, ...props }: Marke
                 })}
             >
                 <TileImageContainer autoSize>
-                    <TileThumbnail src={product.metadata.imageUrl || ''} />
+                    <TileThumbnail src={product.metadata && product.metadata.imageUrl || ''} />
                 </TileImageContainer>
             </Link>
             {!!showDataUnionBadge && (
@@ -355,8 +355,8 @@ const MarketplaceProductTile = ({ product, showDataUnionBadge, ...props }: Marke
             })}
         >
             <Summary
-                name={product.metadata.name || 'Untitled project'}
-                description={product.metadata.description || ''}
+                name={product.metadata && product.metadata.name || 'Untitled project'}
+                description={product.metadata && product.metadata.owner || ''}
             />
         </Link>
     </Tile>

--- a/app/src/shared/hooks/useFetchStreamsFromIndexer.ts
+++ b/app/src/shared/hooks/useFetchStreamsFromIndexer.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useClient } from 'streamr-client-react'
+import { getStreamsFromIndexer, IndexerStream } from '$app/src/services/streams'
+import getClientAddress from '$app/src/getters/getClientAddress'
+import useInterrupt from '$shared/hooks/useInterrupt'
+
+type FetchParameters = {
+    batchSize?: number,
+    allowPublic?: boolean,
+    onlyCurrentUser?: boolean,
+}
+type FetchCallbackType = (search?: string, params?: FetchParameters) =>
+    Promise<[IndexerStream[], boolean, boolean]>
+
+export default function useFetchStreamsFromIndexer(): FetchCallbackType {
+    const client = useClient() // This is only needed for getting user address
+    const itp = useInterrupt()
+    const searchRef = useRef<string>()
+    const onlyCurrentUserRef = useRef<boolean>()
+    const cursorRef = useRef<string | undefined>()
+    const tailStreamRef = useRef<IndexerStream>()
+
+    useEffect(() => {
+        itp().interruptAll()
+    }, [itp, client])
+
+    const fetchStreams = useCallback<FetchCallbackType>(
+        async (search?: string, { batchSize = 1, allowPublic = false, onlyCurrentUser = true } = {}) => {
+            const { requireUninterrupted } = itp(search)
+
+            if (searchRef.current !== search || onlyCurrentUserRef.current !== onlyCurrentUser) {
+                searchRef.current = search
+                onlyCurrentUserRef.current = onlyCurrentUser
+                cursorRef.current = undefined
+            }
+
+            if (typeof cursorRef.current === 'undefined') {
+                tailStreamRef.current = undefined
+            }
+
+            requireUninterrupted()
+            const userAddress = onlyCurrentUserRef.current === true ? await getClientAddress(client, {
+                suppressFailures: true,
+            }) : null
+
+            const result = await getStreamsFromIndexer(batchSize, cursorRef.current, userAddress, searchRef.current)
+
+            const hasMore = true
+            const isFirstBatch = true
+            requireUninterrupted()
+
+            return [result.items, hasMore, isFirstBatch]
+        }, [client, itp])
+
+    return fetchStreams
+}

--- a/app/src/shared/hooks/useStreamStats.ts
+++ b/app/src/shared/hooks/useStreamStats.ts
@@ -1,0 +1,48 @@
+import { useCallback, useMemo } from 'react'
+import { Stream } from 'streamr-client'
+import getCoreConfig from '$app/src/getters/getCoreConfig'
+import { post } from '../utils/api'
+
+export type StreamStats = {
+    stats: any,
+}
+
+const load = async () => {
+    const { theGraphUrl, theHubGraphName } = getCoreConfig()
+    const pageSize = 10
+
+    const result = await post({
+        url: theGraphUrl,
+        data: {
+            query: `
+                query {
+                    streams(
+                        pageSize: ${pageSize},
+                        skip: ${skip},
+                        text: "${search}",
+                    ) {
+                        ${projectFields}
+                    }
+                }
+            `,
+        },
+        useAuthorization: false,
+    })
+
+    return result.data.projectSearch
+}
+
+export const useStreamStats = (streams: Array<Stream>): StreamStats => {
+    const loadStats = useCallback(() => {
+
+    }, [])
+
+    const stats = useMemo(() => {
+        console.log('Streams changed', streams)
+        return []
+    }, [streams])
+
+    return {
+        stats,
+    }
+}

--- a/app/stories/exampleProjectList.json
+++ b/app/stories/exampleProjectList.json
@@ -1,10 +1,12 @@
 [
     {
         "id": "fa6e8192b0096d508415893f49a642338bc80720355b4d45b1e00b465f8066ab",
-        "name": "Credit card transactions",
-        "description": "Credit card transactions. Credit card transactions. Credit card transactions. Credit card transactions. Credit card transactions. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-164501.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/163ebae6e162fc0d539257f8eeb286575fdf68863978ba205f474f591a907ead.jpeg",
+        "metadata": {
+            "name": "Credit card transactions",
+            "description": "Credit card transactions. Credit card transactions. Credit card transactions. Credit card transactions. Credit card transactions. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-164501.jpeg",
+            "owner": "Tester Two"
+        },
         "category": "financial-id",
         "streams": [],
         "state": "NOT_DEPLOYED",
@@ -23,10 +25,12 @@
     },
     {
         "id": "88784dc0445dc39a27b9ce7d630e527ba368666dea5cf8dc955625f713a928d1",
-        "name": "Endangered species tracking sensors",
-        "description": "Endangered species tracking sensors. Endangered species tracking sensors. Endangered species tracking sensors. Endangered species tracking sensors. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-772997.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/5b86e7543728ac7d9f6b3035e3a5cb973c1c08db80e12584ae04229d9d9552db.jpeg",
+        "metadata": {
+            "name": "Endangered species tracking sensors",
+            "description": "Endangered species tracking sensors. Endangered species tracking sensors. Endangered species tracking sensors. Endangered species tracking sensors. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-772997.jpeg",
+            "owner": "Tester Admin"
+        },
         "category": "satellite-id",
         "streams": [],
         "state": "NOT_DEPLOYED",
@@ -45,10 +49,12 @@
     },
     {
         "id": "5af088ad787786fa4f42695275bec834eeb8e16a45f65f4b5c657bf8ad505aba",
-        "name": "Amusement park ride maintenance condition sensors",
-        "description": "Amusement park ride maintenance condition sensors. Amusement park ride maintenance condition sensors. Amusement park ride maintenance condition sensors. Amusement park ride maintenance condition sensors. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-772449.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/d162c59eb9c76dd695480db27caf14c48e6ade7dd9b8c0fd77a58bc2d58df9e8.jpeg",
+        "metadata": {
+            "name": "Amusement park ride maintenance condition sensors",
+            "description": "Amusement park ride maintenance condition sensors. Amusement park ride maintenance condition sensors. Amusement park ride maintenance condition sensors. Amusement park ride maintenance condition sensors. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-772449.jpeg",
+            "owner": "Tester One"
+        },
         "category": "ad-id",
         "streams": [],
         "state": "DEPLOYED",
@@ -67,10 +73,12 @@
     },
     {
         "id": "559c96dbfdf8242bbd65f92a7db4710ca193e408d4e7338d42cdf5657d8396f2",
-        "name": "Fruit ripeness sensors",
-        "description": "Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-701969.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/da67243202fab9c190b69c0922e914e07d7db0405f80f71f44a35ddeadef3a9c.jpeg",
+        "metadata": {
+            "name": "Fruit ripeness sensors",
+            "description": "Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. Fruit ripeness sensors. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-701969.jpeg",
+            "owner": "Tester Admin"
+        },
         "category": "personal-id",
         "streams": [],
         "state": "NOT_DEPLOYED",
@@ -89,10 +97,12 @@
     },
     {
         "id": "c8462e1e5a4535e3e89fa256a0f9f0fa6ba809e0af81f2593c74c819702bc4af",
-        "name": "Glacial snow status in the Rocky Mountains",
-        "description": "Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-301558.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/baa6900197471d455b3b1b2eb14564d830e05ce4f18dc9deecd1b229c926280f.jpeg",
+        "metadata": {
+            "name": "Glacial snow status in the Rocky Mountains",
+            "description": "Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. Glacial snow status in the Rocky Mountains. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-301558.jpeg",
+            "owner": "Tester Admin"
+        },
         "category": "financial-id",
         "streams": [],
         "state": "NOT_DEPLOYED",
@@ -111,10 +121,12 @@
     },
     {
         "id": "48dd109e23aeb94a6ba9831d6078b13badc41b41546c147a4e1897e679160385",
-        "name": "Ride-hailing vehicle tracking data",
-        "description": "Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pretty-woman-traffic-young-vintage.jpg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/5a99ca31c84d651ec5303ca0ee1136efacffe7909472bdc6a487d133a0a80d0c.jpg",
+        "metadata": {
+            "name": "Ride-hailing vehicle tracking data",
+            "description": "Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. Ride-hailing vehicle tracking data. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pretty-woman-traffic-young-vintage.jpg",
+            "owner": "Tester Two"
+        },
         "category": "satellite-id",
         "streams": [],
         "state": "DEPLOYED",
@@ -133,10 +145,12 @@
     },
     {
         "id": "8b1423f7458d78ab129682e7756ab85678f533e66dc083f22d353174c8216cf8",
-        "name": "CO2 atmospheric sensors",
-        "description": "CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-459670.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/a0bb7a3b33bf5f3dda0a64b18f38d7904c1f31df0df3dc6abead41dcddc1281c.jpeg",
+        "metadata": {
+            "name": "CO2 atmospheric sensors",
+            "description": "CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. CO2 atmospheric sensors. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-459670.jpeg",
+            "owner": "Tester Admin"
+        },
         "category": "cryptocurrencies-id",
         "streams": [],
         "state": "NOT_DEPLOYED",
@@ -155,10 +169,12 @@
     },
     {
         "id": "a6fc1d244b64bb6ba9b5e01df56c5b54d65a2d006d949e858bfc67ed2465df58",
-        "name": "People Flow(TM) sensors",
-        "description": "People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-275286.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/6429d7f143517e72d1e4b8e857c2d52cdca199e0dd1a6bc5dbcda6d6b14b1e21.jpeg",
+        "metadata": {
+            "name": "People Flow(TM) sensors",
+            "description": "People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. People Flow(TM) sensors. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-275286.jpeg",
+            "owner": "Tester One"
+        },
         "category": "ad-id",
         "streams": [],
         "state": "DEPLOYED",
@@ -177,10 +193,12 @@
     },
     {
         "id": "920a9a3d4b7eaa08349669b1c8cece3e6156587393a1689145541f55e3a36405",
-        "name": "Plastic packages recycling data stream",
-        "description": "Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. ",
-        "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-802221.jpeg",
-        "thumbnailUrl": "https://streamr-dev-public.s3.eu-west-1.amazonaws.com/product-images/f3f5457dfee934646bd41830ba51520d990e706d93fd39ee4ba9a9748c54dc0a.jpeg",
+        "metadata": {
+            "name": "Plastic packages recycling data stream",
+            "description": "Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. Plastic packages recycling data stream. ",
+            "imageUrl": "https://s3-eu-west-1.amazonaws.com/streamr-dev-public/product-images/test-hero-images/pexels-photo-802221.jpeg",
+            "owner": "Tester One"
+        },
         "category": "satellite-id",
         "streams": [],
         "state": "NOT_DEPLOYED",
@@ -199,8 +217,11 @@
     },
     {
         "id": "4aa07d53461ce9b4904bcaf1f1c67c37daee99935656d1c303fa776ec5a20d88",
-        "name": "Brightness of stars visible in the Northern hemisphere",
-        "description": "Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. ",
+        "metadata": {
+            "name": "Brightness of stars visible in the Northern hemisphere",
+            "description": "Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere. Brightness of stars visible in the Northern hemisphere.",
+            "owner": "Tester One"
+        },
         "category": "satellite-id",
         "streams": [],
         "state": "DEPLOYED",
@@ -214,7 +235,6 @@
         "isFree": true,
         "pricingTokenAddress": "0x8f693ca8D21b157107184d29D398A8D082b38b76",
         "minimumSubscriptionInSeconds": 18,
-        "owner": "Tester One",
         "chain": "ETHEREUM"
     }
 ]


### PR DESCRIPTION
Adds a new hook `useFetchStreamsFromIndexer` which uses `stream-metrics-indexer` to load streams with stats included. API is compatible with existing `useFetchStreams` which uses `streamr-client` to fetch data.