### PR TITLE
FRONT-1345: Tastefull toasts

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -41,6 +41,7 @@
         "prosemirror-model": "1.13.3"
     },
     "dependencies": {
+        "@atlaskit/icon": "^21.11.5",
         "@babel/core": "^7.17.12",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-proposal-export-namespace-from": "^7.12.1",

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -38,6 +38,7 @@ import routes from '$routes'
 import history from '../history'
 import '../analytics'
 import { Layer } from '../utils/Layer'
+import styled from 'styled-components'
 
 // Wrap authenticated components here instead of render() method
 // Wrap each Route to an ErrorBoundary
@@ -120,6 +121,7 @@ const App = () => (
                                     </Switch>
                                     <Notifications />
                                     <Container id={Layer.Modal} />
+                                    <ToastContainer id={Layer.Toast} />
                                 </ActivityResourceProvider>
                                 <AnalyticsTracker />
                             </GlobalInfoWatcher>
@@ -132,3 +134,13 @@ const App = () => (
 )
 
 export default App
+
+const ToastContainer = styled(Container)`
+    bottom: 0;
+    left: 0;
+    max-width: 100%;
+    padding-bottom: 24px;
+    padding-right: 24px;
+    position: fixed;
+    z-index: 10;
+`

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -6,6 +6,7 @@ import '$shared/assets/stylesheets'
 import '@ibm/plex/css/ibm-plex.css'
 import '$utils/setupSnippets'
 
+import styled from 'styled-components'
 import StreamrClientProvider from '$shared/components/StreamrClientProvider'
 import LoginPage from '$app/src/pages/LoginPage'
 import LogoutPage from '$app/src/pages/LogoutPage'
@@ -38,7 +39,6 @@ import routes from '$routes'
 import history from '../history'
 import '../analytics'
 import { Layer } from '../utils/Layer'
-import styled from 'styled-components'
 
 // Wrap authenticated components here instead of render() method
 // Wrap each Route to an ErrorBoundary

--- a/app/src/shared/components/AbstractToast.tsx
+++ b/app/src/shared/components/AbstractToast.tsx
@@ -1,0 +1,119 @@
+import React, { HTMLAttributes } from 'react'
+import styled, { css, keyframes } from 'styled-components'
+import { useDiscardableEffect } from 'toasterhea'
+import { useLayoutEffect, useReducer, useRef, useState } from 'react'
+
+const toastIn = keyframes`
+    from {
+        transform: translateX(100%) translateZ(0);
+    }
+    to {
+        transform: translateX(0) translateZ(0);
+    }
+`
+
+const toastSqueeze = keyframes`
+    from {
+        transform: translateX(100%) translateZ(0);
+    }
+    to {
+        height: 0;
+        margin-top: 0;
+        margin-left: 0;
+        transform: translateX(100%) translateZ(0);
+    }
+`
+
+const toastOut = keyframes`
+    from {
+        transform: translateX(0) translateZ(0);
+    }
+    to {
+        transform: translateX(100%) translateZ(0);
+    }
+`
+
+export default function AbstractToast({ children, ...props }: HTMLAttributes<HTMLDivElement>) {
+    const [hidden, hide] = useReducer(() => true, false)
+
+    const [squeezed, squeeze] = useReducer(() => true, false)
+
+    const [height, setHeight] = useState(0)
+
+    const ref = useRef<HTMLDivElement>(null)
+
+    const innerRef = useRef<HTMLDivElement>(null)
+
+    const mountedAtRef = useRef(performance.now())
+
+    useDiscardableEffect((discard) => {
+        const { current: root } = ref
+
+        root?.addEventListener('animationend', ({ animationName }: AnimationEvent) => {
+            if (animationName === 'toastOut') {
+                squeeze()
+            }
+
+            if (animationName === 'toastSqueeze') {
+                discard()
+            }
+        })
+
+        /**
+         * Let's make sure each open toast stays visible for at least a second. Otherwise
+         * it's jumpy and a bit confusing.
+         */
+        setTimeout(hide, Math.max(0, 1000 - (performance.now() - mountedAtRef.current)))
+    })
+
+    useLayoutEffect(() => {
+        const { current: root } = innerRef
+
+        if (!root) {
+            return
+        }
+
+        const { height } = root.getBoundingClientRect()
+
+        setHeight(height)
+    }, [children])
+
+    return (
+        <Root
+            ref={ref}
+            style={{
+                height: `${height}px`,
+            }}
+            $hidden={hidden}
+            $squeezed={squeezed}
+        >
+            <div {...props} ref={innerRef}>
+                {children}
+            </div>
+        </Root>
+    )
+}
+
+const Root = styled.div<{ $hidden?: boolean; $squeezed?: boolean }>`
+    transition: 200ms height;
+    margin-top: 12px;
+    margin-left: 24px;
+
+    ${({ $hidden, $squeezed }) => {
+        if (!$hidden) {
+            return css`
+                animation: 0.15s 1 ${toastIn} both ease-in;
+            `
+        }
+
+        if ($squeezed) {
+            return css`
+                animation: 0.15s 1 ${toastSqueeze} forwards ease-in;
+            `
+        }
+
+        return css`
+            animation: 0.15s 1 ${toastOut} forwards ease-in;
+        `
+    }}
+`

--- a/app/src/shared/hooks/usePreventNavigatingAway.ts
+++ b/app/src/shared/hooks/usePreventNavigatingAway.ts
@@ -25,20 +25,20 @@ export default function usePreventNavigatingAway(message: string, isDirty: () =>
         return () => {
             unblock?.()
         }
-    }, [history, isDirty])
+    }, [history, isDirty, message])
 
     useBeforeUnload(
         useCallback(
             (e) => {
                 if (isDirty()) {
                     e.returnValue = message
-    
+
                     return message
                 }
 
                 return ''
             },
-            [isDirty],
+            [isDirty, message],
         ),
     )
 }

--- a/app/src/shared/toasts/AbstractToast.tsx
+++ b/app/src/shared/toasts/AbstractToast.tsx
@@ -102,6 +102,7 @@ const Root = styled.div<{ $hidden?: boolean; $squeezed?: boolean }>`
     margin-top: 12px;
     margin-left: 24px;
     transition: 200ms height;
+    width: max-content;
 
     ${({ $hidden, $squeezed }) => {
         if (!$hidden) {

--- a/app/src/shared/toasts/AbstractToast.tsx
+++ b/app/src/shared/toasts/AbstractToast.tsx
@@ -5,7 +5,7 @@ import { useLayoutEffect, useReducer, useRef, useState } from 'react'
 
 const toastIn = keyframes`
     from {
-        transform: translateX(100%) translateZ(0);
+        transform: translateX(-100%) translateZ(0);
     }
     to {
         transform: translateX(0) translateZ(0);
@@ -14,13 +14,13 @@ const toastIn = keyframes`
 
 const toastSqueeze = keyframes`
     from {
-        transform: translateX(100%) translateZ(0);
+        transform: translateX(-100%) translateZ(0);
     }
     to {
         height: 0;
         margin-top: 0;
         margin-left: 0;
-        transform: translateX(100%) translateZ(0);
+        transform: translateX(-100%) translateZ(0);
     }
 `
 
@@ -29,7 +29,7 @@ const toastOut = keyframes`
         transform: translateX(0) translateZ(0);
     }
     to {
-        transform: translateX(100%) translateZ(0);
+        transform: translateX(-100%) translateZ(0);
     }
 `
 
@@ -50,11 +50,11 @@ export default function AbstractToast({ children, ...props }: HTMLAttributes<HTM
         const { current: root } = ref
 
         root?.addEventListener('animationend', ({ animationName }: AnimationEvent) => {
-            if (animationName === 'toastOut') {
+            if (animationName === toastOut.getName()) {
                 squeeze()
             }
 
-            if (animationName === 'toastSqueeze') {
+            if (animationName === toastSqueeze.getName()) {
                 discard()
             }
         })
@@ -95,9 +95,13 @@ export default function AbstractToast({ children, ...props }: HTMLAttributes<HTM
 }
 
 const Root = styled.div<{ $hidden?: boolean; $squeezed?: boolean }>`
-    transition: 200ms height;
+    background: white;
+    box-shadow: 0 8px 12px 0 #52525226, 0 0 1px 0 #00000040;
+    border-radius: 8px;
+    color: #323232;
     margin-top: 12px;
     margin-left: 24px;
+    transition: 200ms height;
 
     ${({ $hidden, $squeezed }) => {
         if (!$hidden) {

--- a/app/src/shared/toasts/Toast.tsx
+++ b/app/src/shared/toasts/Toast.tsx
@@ -3,6 +3,7 @@ import AbstractToast from './AbstractToast'
 import CheckCircleIcon from '@atlaskit/icon/glyph/check-circle'
 import InfoIcon from '@atlaskit/icon/glyph/info'
 import ErrorIcon from '@atlaskit/icon/glyph/error'
+import CrossIcon from '@atlaskit/icon/glyph/cross'
 import styled from 'styled-components'
 import { MEDIUM } from '../utils/styled'
 import Spinner from '../components/Spinner'
@@ -108,10 +109,31 @@ export default function Toast({
                         </Buttons>
                     )}
                 </Body>
+                {type !== ToastType.Processing && (
+                    <CloseButton onClick={() => void onReject?.()} type="button">
+                        <CrossIcon label="Dismiss" size="small" />
+                    </CloseButton>
+                )}
             </Form>
         </AbstractToast>
     )
 }
+
+const CloseButton = styled.button`
+    align-items: center;
+    appearance: none;
+    color: #525252;
+    display: flex;
+    flex-shrink: 0;
+    height: 24px;
+    justify-content: center;
+    margin-left: 16px;
+    width: 24px;
+    padding: 0;
+    outline: 0;
+    border: 0;
+    background: none;
+`
 
 const Dot = styled.div`
     background: #525252;

--- a/app/src/shared/toasts/Toast.tsx
+++ b/app/src/shared/toasts/Toast.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react'
-import AbstractToast from './AbstractToast'
 import CheckCircleIcon from '@atlaskit/icon/glyph/check-circle'
 import InfoIcon from '@atlaskit/icon/glyph/info'
 import ErrorIcon from '@atlaskit/icon/glyph/error'
@@ -7,6 +6,7 @@ import CrossIcon from '@atlaskit/icon/glyph/cross'
 import styled from 'styled-components'
 import { MEDIUM } from '../utils/styled'
 import Spinner from '../components/Spinner'
+import AbstractToast from './AbstractToast'
 
 export enum ToastType {
     Info = 'info',

--- a/app/src/shared/toasts/Toast.tsx
+++ b/app/src/shared/toasts/Toast.tsx
@@ -1,0 +1,207 @@
+import React, { useEffect } from 'react'
+import AbstractToast from './AbstractToast'
+import CheckCircleIcon from '@atlaskit/icon/glyph/check-circle'
+import InfoIcon from '@atlaskit/icon/glyph/info'
+import ErrorIcon from '@atlaskit/icon/glyph/error'
+import styled from 'styled-components'
+import { MEDIUM } from '../utils/styled'
+import Spinner from '../components/Spinner'
+
+export enum ToastType {
+    Info = 'info',
+    Processing = 'processing',
+    Success = 'success',
+    Warning = 'warn',
+}
+
+interface Props {
+    cancelLabel?: string
+    desc?: string
+    okLabel?: string
+    onReject?: (reason?: any) => void
+    onResolve?: () => void
+    title?: string
+    type?: ToastType
+    canSubmit?: boolean
+    autoCloseAfter?: number | boolean
+}
+
+const defaultAutoCloseAfter = 3
+
+export default function Toast({
+    type = ToastType.Info,
+    title = 'внимание!',
+    desc,
+    okLabel,
+    cancelLabel,
+    onResolve,
+    onReject,
+    canSubmit = true,
+    autoCloseAfter: autoCloseAfterProp = true,
+}: Props) {
+    const autoCloseAfter =
+        type !== ToastType.Processing && okLabel == null && cancelLabel == null
+            ? autoCloseAfterProp === true
+                ? defaultAutoCloseAfter
+                : autoCloseAfterProp
+            : false
+
+    useEffect(() => {
+        if (autoCloseAfter === false) {
+            return () => void 0
+        }
+
+        const timeoutId = setTimeout(() => void onReject?.(), autoCloseAfter * 1000)
+
+        return () => void clearTimeout(timeoutId)
+    }, [autoCloseAfter, onReject])
+
+    return (
+        <AbstractToast>
+            <Form
+                onSubmit={(e) => {
+                    e.preventDefault()
+
+                    if (canSubmit) {
+                        onResolve?.()
+                    }
+                }}
+            >
+                <>
+                    {type === ToastType.Success && (
+                        <IconWrap $color="#0EAC1B">
+                            <CheckCircleIcon label="Success" />
+                        </IconWrap>
+                    )}
+                    {type === ToastType.Info && (
+                        <IconWrap $color="#6240AF">
+                            <InfoIcon label="Info" />
+                        </IconWrap>
+                    )}
+                    {type === ToastType.Warning && (
+                        <IconWrap $color="#FF5C00">
+                            <ErrorIcon label="Error" />
+                        </IconWrap>
+                    )}
+                    {type === ToastType.Processing && (
+                        <IconWrap>
+                            <Spinner color="blue" />
+                        </IconWrap>
+                    )}
+                </>
+                <Body>
+                    <h4>{title}</h4>
+                    {typeof desc === 'string' ? <p>{desc}</p> : desc}
+                    {(okLabel || cancelLabel) != null && (
+                        <Buttons>
+                            {okLabel != null && (
+                                <Button type="submit" disabled={!canSubmit}>
+                                    {okLabel}
+                                </Button>
+                            )}
+                            {okLabel != null && cancelLabel != null && <Dot />}
+                            {cancelLabel != null && (
+                                <Button type="button" onClick={() => void onReject?.()}>
+                                    {cancelLabel}
+                                </Button>
+                            )}
+                        </Buttons>
+                    )}
+                </Body>
+            </Form>
+        </AbstractToast>
+    )
+}
+
+const Dot = styled.div`
+    background: #525252;
+    height: 3px;
+    margin-left: 8px;
+    margin-right: 8px;
+    width: 3px;
+`
+
+const Form = styled.form`
+    align-items: start;
+    display: flex;
+    max-width: 100%;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    width: 400px;
+`
+
+const IconWrap = styled.div<{ $color?: string }>`
+    height: 24px;
+    width: 24px;
+    position: relative;
+    display: flex;
+    items-center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-right: 16px;
+    color: ${({ $color = 'inherit' }) => $color};
+`
+
+const Body = styled.div`
+    flex-grow: 1;
+    min-width: 0;
+    padding: 3px 0;
+    font-size: 14px;
+
+    p,
+    h4,
+    ul,
+    ol {
+        font-size: inherit;
+        overflow-wrap: break-word;
+    }
+
+    h4 {
+        margin: 0;
+        line-height: normal;
+    }
+
+    p,
+    ul,
+    ol {
+        margin: 8px 0 0;
+        line-height: 20px;
+    }
+
+    h4 {
+        font-weight: ${MEDIUM};
+    }
+
+    ol {
+        list-style-position: inside;
+    }
+`
+
+const Buttons = styled.div`
+    align-items: center;
+    display: flex;
+    line-height: normal;
+    margin-top: 8px;
+`
+
+const Button = styled.button`
+    background: none;
+    border: 0;
+    color: #0324ff;
+    display: block;
+    font-size: 14px;
+    font-weight: ${MEDIUM};
+    outline: 0;
+    padding: 0;
+
+    :hover {
+        color: #000d67;
+    }
+
+    :disabled {
+        color: inherit;
+        opacity: 0.5;
+    }
+`

--- a/app/src/utils/Layer.ts
+++ b/app/src/utils/Layer.ts
@@ -1,3 +1,4 @@
 export const Layer = {
     Modal: 'modals',
+    Toast: 'toasts',
 }


### PR DESCRIPTION
This PR does not come with any uses of the new toasts. Eventually though it'll replace all `Notification.push` hits.

To pop up a simple detached toast you can do
```ts
async function onClick() {
    await toaster(Toast, Layer.Toast).pop({
        title: 'My toast',
        type: ToastType.Success,
    })
}
```

Note that dismissing a toast manually or via the `autoCloseAfter` (automatically) throws an exception. Technically it's a promise rejection. That's how it's build. You can build a toastable that resolves on dismiss, no probs. It's failry easy actually!

Good thing about the new toasts? They're highly customizable because… `toasterhea` doesn't come with any toastables ("Bring your own bread, eh!?").

This is how you create a confirmation toast:

```tsx
async function onClick() {
    try {
        await toaster(Toast, Layer.Toast).pop({
            title: 'Feel adventurous?',
            okLabel: 'Yes, bring it on!',
            cancelLabel: 'Nah, pass',
        })

        // She said yes!
    } catch (e) {
        // Toast dismissed!
    }
}
```

And so on!

---

- [x] Fix related eslint warinings.