### PR TITLE
FRONT-1341: Go back like a Pro

### DIFF
--- a/app/src/pages/NewStreamListingPage/index.tsx
+++ b/app/src/pages/NewStreamListingPage/index.tsx
@@ -29,6 +29,7 @@ import LoadingIndicator from '$shared/components/LoadingIndicator'
 import { useAuthController } from '$auth/hooks/useAuthController'
 import StreamTable from '$shared/components/StreamTable'
 import Tabs, { Tab } from '$shared/components/Tabs'
+import { RouteMemoryKey, useRecall, useRemember } from '$shared/stores/routeMemory'
 import routes from '$routes'
 
 enum StreamSelection {
@@ -109,9 +110,17 @@ const NewStreamListingPage: React.FC = () => {
     const [search, setSearch] = useState<string>('')
     const [orderBy, setOrderBy] = useState(DEFAULT_ORDER_BY)
     const [orderDirection, setOrderDirection] = useState(DEFAULT_ORDER_DIRECTION)
-    const [streamsSelection, setStreamsSelection] = useState<StreamSelection>(StreamSelection.All)
+    const [streamsSelection, setStreamsSelection] = useState<StreamSelection>(
+        useRecall(RouteMemoryKey.lastStreamListingSelection()) as StreamSelection || StreamSelection.All
+    )
     const isUserAuthenticated = useIsAuthenticated()
     const { currentAuthSession } = useAuthController()
+
+    const remember = useRemember()
+
+    useEffect(() => {
+        remember(RouteMemoryKey.lastStreamListingSelection(), streamsSelection)
+    }, [remember, streamsSelection])
 
     const streamsQuery = useInfiniteQuery({
         queryKey: ["streams", search, streamsSelection, currentAuthSession.address, orderBy, orderDirection],

--- a/app/src/pages/StreamPage.tsx
+++ b/app/src/pages/StreamPage.tsx
@@ -27,6 +27,7 @@ import getNativeTokenName from '$shared/utils/nativeToken'
 import { useAuthController } from '$auth/hooks/useAuthController'
 import { useInvalidateAbilities } from '$shared/stores/abilities'
 import Tabs, { Tab } from '$shared/components/Tabs'
+import { RouteMemoryKey, useKeep } from '$shared/stores/routeMemory'
 import routes from '$routes'
 import RelatedProjects from './AbstractStreamEditPage/RelatedProjects'
 
@@ -169,6 +170,8 @@ export default function StreamPage({
 
     const { pathname } = useLocation()
 
+    const keep = useKeep()
+
     return (
         <>
             <form
@@ -259,6 +262,11 @@ export default function StreamPage({
                                         tag={Link}
                                         to={routes.streams.overview({ id: streamId })}
                                         selected="to"
+                                        onClick={() =>
+                                            void keep(
+                                                RouteMemoryKey.lastStreamListingSelection(),
+                                            )
+                                        }
                                     >
                                         Stream overview
                                         {!clean && <Asterisk />}
@@ -268,6 +276,11 @@ export default function StreamPage({
                                         tag={Link}
                                         to={routes.streams.connect({ id: streamId })}
                                         selected="to"
+                                        onClick={() =>
+                                            void keep(
+                                                RouteMemoryKey.lastStreamListingSelection(),
+                                            )
+                                        }
                                     >
                                         Connect
                                     </Tab>
@@ -276,6 +289,11 @@ export default function StreamPage({
                                         tag={Link}
                                         to={routes.streams.liveData({ id: streamId })}
                                         selected="to"
+                                        onClick={() =>
+                                            void keep(
+                                                RouteMemoryKey.lastStreamListingSelection(),
+                                            )
+                                        }
                                     >
                                         Live data
                                     </Tab>

--- a/app/src/pages/StreamPage.tsx
+++ b/app/src/pages/StreamPage.tsx
@@ -86,7 +86,7 @@ const SaveButton = styled(Button)`
 type ContainerBoxProps = {
     children?: React.ReactNode
     disabled?: boolean
-    streamId?: string,
+    streamId?: string
     showSaveButton?: boolean
     fullWidth?: boolean
 }
@@ -98,7 +98,13 @@ const TitleContainer = styled.div`
 
 const getCryptoModal = toaster(GetCryptoModal, Layer.Modal)
 
-function ContainerBox({ children, disabled, streamId, showSaveButton = true, fullWidth = false }: ContainerBoxProps) {
+function ContainerBox({
+    children,
+    disabled,
+    streamId,
+    showSaveButton = true,
+    fullWidth = false,
+}: ContainerBoxProps) {
     return (
         <Outer>
             <Inner fullWidth={fullWidth}>
@@ -109,14 +115,18 @@ function ContainerBox({ children, disabled, streamId, showSaveButton = true, ful
                     </SaveButton>
                 )}
             </Inner>
-            {streamId != null && (
-                <RelatedProjects streamId={streamId} />
-            )}
+            {streamId != null && <RelatedProjects streamId={streamId} />}
         </Outer>
     )
 }
 
-export default function StreamPage({ children, loading = false, includeContainerBox = true, showSaveButton = true, fullWidth = false }) {
+export default function StreamPage({
+    children,
+    loading = false,
+    includeContainerBox = true,
+    showSaveButton = true,
+    fullWidth = false,
+}) {
     const { streamId, transientStreamId } = useCurrentDraft()
 
     const busy = useIsCurrentDraftBusy()
@@ -189,7 +199,11 @@ export default function StreamPage({ children, loading = false, includeContainer
 
                                 if (
                                     !assignments.some((assignment) => {
-                                        return 'user' in assignment && assignment.user.toLowerCase() === address.toLowerCase()
+                                        return (
+                                            'user' in assignment &&
+                                            assignment.user.toLowerCase() ===
+                                                address.toLowerCase()
+                                        )
                                     })
                                 ) {
                                     return
@@ -222,32 +236,57 @@ export default function StreamPage({ children, loading = false, includeContainer
                 }}
             >
                 <Layout>
-                    <MarketplaceHelmet title={streamId ? `Stream ${streamId}` : 'New stream'} />
+                    <MarketplaceHelmet
+                        title={streamId ? `Stream ${streamId}` : 'New stream'}
+                    />
                     <DetailsPageHeader
                         backButtonLink={routes.streams.index()}
                         pageTitle={
                             <TitleContainer>
-                                <span title={streamId}>{streamId ? truncateStreamName(streamId, 50) : transientStreamId || 'New stream'}</span>
+                                <span title={streamId}>
+                                    {streamId
+                                        ? truncateStreamName(streamId, 50)
+                                        : transientStreamId || 'New stream'}
+                                </span>
                                 {streamId ? <CopyButton valueToCopy={streamId} /> : ''}
                             </TitleContainer>
                         }
                         rightComponent={
                             streamId ? (
                                 <Tabs selection={pathname}>
-                                    <Tab id="overview" tag={Link} to={routes.streams.overview({ id: streamId })} selected="to">
+                                    <Tab
+                                        id="overview"
+                                        tag={Link}
+                                        to={routes.streams.overview({ id: streamId })}
+                                        selected="to"
+                                    >
                                         Stream overview
                                         {!clean && <Asterisk />}
                                     </Tab>
-                                    <Tab id="connect" tag={Link} to={routes.streams.connect({ id: streamId })} selected="to">
+                                    <Tab
+                                        id="connect"
+                                        tag={Link}
+                                        to={routes.streams.connect({ id: streamId })}
+                                        selected="to"
+                                    >
                                         Connect
                                     </Tab>
-                                    <Tab id="liveData" tag={Link} to={routes.streams.liveData({ id: streamId })} selected="to">
+                                    <Tab
+                                        id="liveData"
+                                        tag={Link}
+                                        to={routes.streams.liveData({ id: streamId })}
+                                        selected="to"
+                                    >
                                         Live data
                                     </Tab>
                                 </Tabs>
                             ) : (
                                 <div>
-                                    <Button disabled={busy || clean} kind="primary" type="submit">
+                                    <Button
+                                        disabled={busy || clean}
+                                        kind="primary"
+                                        type="submit"
+                                    >
                                         Save
                                     </Button>
                                 </div>

--- a/app/src/shared/components/DetailsPageHeader/index.tsx
+++ b/app/src/shared/components/DetailsPageHeader/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import { COLORS, DESKTOP, LAPTOP, MAX_BODY_WIDTH, TABLET } from '$shared/utils/styled'
 import SvgIcon from '$shared/components/SvgIcon'
+import { RouteMemoryKey, useKeep } from '$shared/stores/routeMemory'
 
 export type DetailsPageHeaderProps = {
     backButtonLink?: string
@@ -11,13 +12,20 @@ export type DetailsPageHeaderProps = {
 }
 
 export const DetailsPageHeader: FunctionComponent<DetailsPageHeaderProps> = ({ backButtonLink, pageTitle, rightComponent }) => {
+    const keep = useKeep()
+
     return (
         <DetailsPageHeaderBackground>
             <DetailsPageHeaderContainer>
                 <DetailsPageHeaderBar>
                     <LeftSideContainer>
                         {!!backButtonLink && (
-                            <BackLink to={backButtonLink}>
+                            <BackLink
+                                to={backButtonLink}
+                                onClick={() => {
+                                    keep(RouteMemoryKey.lastStreamListingSelection())
+                                }}
+                            >
                                 <BackButtonIcon name={'backArrow'}></BackButtonIcon>
                             </BackLink>
                         )}

--- a/app/src/shared/components/Globals.tsx
+++ b/app/src/shared/components/Globals.tsx
@@ -1,5 +1,6 @@
 import { useIsPersistingAnyStreamDraft } from '$shared/stores/streamEditor'
 import usePreventNavigatingAway from '../hooks/usePreventNavigatingAway'
+import { useRouteMemoryWipeEffect } from '../stores/routeMemory'
 
 export default function Globals() {
     const isPersistingAnyStreamDraft = useIsPersistingAnyStreamDraft()
@@ -9,6 +10,8 @@ export default function Globals() {
             return typeof destination === 'undefined' && isPersistingAnyStreamDraft
         }
     })
+
+    useRouteMemoryWipeEffect()
 
     return null
 }

--- a/app/src/shared/stores/routeMemory.ts
+++ b/app/src/shared/stores/routeMemory.ts
@@ -1,0 +1,145 @@
+/**
+ * Route memory is a string-to-string map that gets erased on every `PUSH`
+ * action called on the `history` object.
+ *
+ * By design you can instruct the erasing mechanism to omit selected keys.
+ * This will effectively make the memorized keys and values transfer to the
+ * new location where they can either be kept again (see `useKeep`)
+ * or erased on the next route change.
+ */
+
+import { create } from 'zustand'
+import produce from 'immer'
+import { useHistory } from 'react-router-dom'
+import { useEffect } from 'react'
+
+export const RouteMemoryKey = {
+    lastStreamListingSelection() {
+        return JSON.stringify(['lastStreamListingSelection'])
+    },
+}
+
+interface Store {
+    remember: (key: string, value: string, options?: { keep?: boolean }) => void
+    wipe: () => void
+    keep: (key: string) => void
+    items: Partial<
+        Record<
+            string,
+            {
+                keep: boolean
+                value: string
+            }
+        >
+    >
+}
+
+const useRouteMemoryStore = create<Store>((set, get) => {
+    return {
+        items: {},
+
+        remember(key, value, { keep = true } = {}) {
+            set((current) =>
+                produce(current, (draft) => {
+                    if (value == null) {
+                        return void delete draft.items[key]
+                    }
+
+                    draft.items[key] = {
+                        keep,
+                        value,
+                    }
+                }),
+            )
+        },
+
+        wipe() {
+            set((current) =>
+                produce(current, (draft) => {
+                    for (const key in draft.items) {
+                        const item = draft.items[key]
+
+                        if (item == null || !Object.prototype.hasOwnProperty.call(draft.items, key)) {
+                            continue
+                        }
+
+                        if (item.keep) {
+                            item.keep = false
+                            continue
+                        }
+
+                        delete draft.items[key]
+                    }
+                }),
+            )
+        },
+
+        keep(key) {
+            set((current) =>
+                produce(current, (draft) => {
+                    const item = draft.items[key]
+
+                    if (item == null || !Object.prototype.hasOwnProperty.call(draft.items, key)) {
+                        return
+                    }
+
+                    item.keep = true
+                }),
+            )
+        },
+    }
+})
+
+/**
+ * @returns A function that writes a string value at a given key into the current route's memory.
+ */
+export function useRemember() {
+    return useRouteMemoryStore(({ remember }) => remember)
+}
+
+/**
+ * @param key Key used for route memory lookups.
+ * @returns The memorized value.
+ */
+export function useRecall(key: string) {
+    return useRouteMemoryStore(({ items }) => {
+        if (!Object.prototype.hasOwnProperty.call(items, key)) {
+            return
+        }
+
+        return items[key]?.value
+    })
+}
+
+/**
+ * @returns A function that makes the memory wipe mechanism omit
+ * given key. It's gonna be available in the new location.
+ *
+ * If you wanna do a round trip, memorize something on page "A",
+ * go to another page, "B", get back to "A" and have the memorized
+ * value still available, you'll have to call the returned function
+ * on page "B".
+ */
+export function useKeep() {
+    return useRouteMemoryStore(({ keep }) => keep)
+}
+
+/**
+ * An effect hook that listens for `PUSH` history actions and triggers
+ * a route memory wipe.
+ */
+export function useRouteMemoryWipeEffect() {
+    const history = useHistory()
+
+    const { wipe } = useRouteMemoryStore()
+
+    useEffect(() => {
+        return history.listen((_, action) => {
+            if (action !== 'PUSH') {
+                return
+            }
+
+            wipe()
+        })
+    }, [history, wipe])
+}


### PR DESCRIPTION
In this PR I make sure that when you go to "Your streams", open one, and hit "←" (go back) you'll end up seeing the list of your streams, not the list of \*all\* streams. This used to be quite annoying and inconsistent.

@tumppi @pmichalowski here I introduce a new concept: Route memory. Have a look at the `routeMemory.ts` to learn more about it. Naming may seem a bit off, or not. I'm quite happy with it, actually.

LMK if you have any other ideas.

Here are some I considered:
- Local/session storage: without some trickery this would make "Streams" link (top nav) go back to your previous selection. Not ideal.
- More routes: how would the connect page know where to go if I came through Stream list → Overview → Connect?