### PR TITLE
New copy toasts

### DIFF
--- a/app/src/marketplace/containers/ProjectEditing/BeneficiaryAddress.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/BeneficiaryAddress.tsx
@@ -5,8 +5,6 @@ import WithInputActions from '$shared/components/WithInputActions'
 import PopoverItem from '$shared/components/Popover/PopoverItem'
 import Text from '$ui/Text'
 import useCopy from '$shared/hooks/useCopy'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 import { truncate } from '$shared/utils/text'
 import { isEthereumAddress } from '$mp/utils/validate'
 import useValidation from '$mp/containers/ProductController/useValidation'
@@ -89,10 +87,8 @@ export const BeneficiaryAddress: FunctionComponent<BeneficiaryAddressProps> = ({
             return
         }
 
-        copy(beneficiaryAddress)
-        Notification.push({
-            title: 'Copied',
-            icon: NotificationIcon.CHECKMARK,
+        copy(beneficiaryAddress, {
+            toastMessage: 'Copied',
         })
     }, [copy, beneficiaryAddress])
 

--- a/app/src/pages/AbstractStreamEditPage/InfoSection/StreamId.tsx
+++ b/app/src/pages/AbstractStreamEditPage/InfoSection/StreamId.tsx
@@ -9,8 +9,6 @@ import Text from '$ui/Text'
 import Select from '$ui/Select'
 import Errors, { MarketplaceTheme } from '$ui/Errors'
 import useCopy from '$shared/hooks/useCopy'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 import { truncate } from '$shared/utils/text'
 import { useAuthController } from "$auth/hooks/useAuthController"
 import { DraftValidationError, useCurrentDraftError, useSetCurrentDraftError, useSetCurrentDraftTransientStreamId } from '$shared/stores/streamEditor'
@@ -19,12 +17,7 @@ import useStreamOwnerOptions, { ADD_ENS_DOMAIN_VALUE } from './useStreamOwnerOpt
 export const ENS_DOMAINS_URL = 'https://ens.domains'
 
 export function ReadonlyStreamId({ streamId }: { streamId: string }) {
-    const { copy, isCopied } = useCopy(() => {
-        Notification.push({
-            title: 'Stream ID copied',
-            icon: NotificationIcon.CHECKMARK,
-        })
-    })
+    const { copy, isCopied } = useCopy()
 
     return (
         <StreamId>
@@ -36,9 +29,14 @@ export function ReadonlyStreamId({ streamId }: { streamId: string }) {
             </Pathname>
             <div>
                 <Label />
-                <Button kind="secondary" onClick={() => void copy(streamId || '')} type="button">
-                    {!isCopied && 'Copy'}
-                    {!!isCopied && 'Copied!'}
+                <Button
+                    kind="secondary"
+                    onClick={() => void copy(streamId || '', {
+                        toastMessage: 'Stream ID copied',
+                    })}
+                    type="button"
+                >
+                    {isCopied ? 'Copied!' : 'Copy'}
                 </Button>
             </div>
         </StreamId>

--- a/app/src/shared/components/CopyButton/CopyButton.tsx
+++ b/app/src/shared/components/CopyButton/CopyButton.tsx
@@ -2,8 +2,6 @@ import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components'
 import Button from '$shared/components/Button'
 import useCopy from '$shared/hooks/useCopy'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 import SvgIcon from '$shared/components/SvgIcon'
 
 const Btn = styled(Button)`
@@ -23,21 +21,20 @@ const Btn = styled(Button)`
 type CopyButtonProps = {
     valueToCopy: string
     notificationTitle?: string
-    notificationDescription?: string
     className?: string
 }
 
 export const CopyButton: FunctionComponent<CopyButtonProps> = ({
     valueToCopy,
     notificationTitle = 'Stream ID copied',
-    notificationDescription,
     className,
 }) => {
     const { copy } = useCopy()
     const handleCopy = useCallback(() => {
-        copy(valueToCopy)
-        Notification.push({ title: notificationTitle, description: notificationDescription, icon: NotificationIcon.CHECKMARK })
-    }, [copy, notificationDescription, notificationTitle, valueToCopy])
+        copy(valueToCopy, {
+            toastMessage: notificationTitle,
+        })
+    }, [copy, notificationTitle, valueToCopy])
     return (
         <Btn onClick={handleCopy} type={'button'} kind={'secondary'} size={'mini'} className={className}>
             <SvgIcon name={'copy'} />

--- a/app/src/shared/components/StreamConnect/index.tsx
+++ b/app/src/shared/components/StreamConnect/index.tsx
@@ -1,15 +1,13 @@
 import React, { FunctionComponent, useMemo, useState } from 'react'
 import { CodeSnippet, Tabs } from '@streamr/streamr-layout'
 import styled from 'styled-components'
-import copy from 'copy-to-clipboard'
 import { COLORS, MEDIUM } from '$shared/utils/styled'
 import SvgIcon from '$shared/components/SvgIcon'
 import Button from '$shared/components/Button'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 import SelectField2 from '$mp/components/SelectField2'
 import { StreamId } from '$shared/types/stream-types'
 import {truncateStreamName} from "$shared/utils/text"
+import useCopy from '$shared/hooks/useCopy'
 
 export const StreamConnect: FunctionComponent<{streams: StreamId[]}> = ({streams}) => {
     const [streamId, setSelectedStream] = useState<StreamId>(streams[0])
@@ -118,10 +116,7 @@ mqtt.subscribe('${streamId}', (msg) => {
         return mqttSnippetHeader + (action === 'publish' ? mqttPublish : mqttSubscribe)
     }, [mqttSnippetHeader, mqttPublish, mqttSubscribe, action])
 
-    const handleCopy = (snippet: string): void => {
-        copy(snippet)
-        Notification.push({title: 'Copied!', icon: NotificationIcon.CHECKMARK})
-    }
+    const { copy } = useCopy()
 
     const currentBrokerSnippet = useMemo(() => {
         let snippet: string
@@ -214,7 +209,12 @@ mqtt.subscribe('${streamId}', (msg) => {
                             <CodeSnippet language={'javascript'}>{lightNodeSnippet}</CodeSnippet>
                         </StreamConnectLightNodeSnippetContainer>
                         <StreamConnectSnippetCopyContainer>
-                            <Button kind={'secondary'} onClick={() => handleCopy(lightNodeSnippet)}>
+                            <Button
+                                kind="secondary"
+                                onClick={() => void copy(currentBrokerSnippet, {
+                                    toastMessage: 'Copied',
+                                })}
+                            >
                                 Copy
                             </Button>
                         </StreamConnectSnippetCopyContainer>
@@ -235,7 +235,12 @@ mqtt.subscribe('${streamId}', (msg) => {
                             </Tabs.Item>
                         </Tabs>
                         <StreamConnectSnippetCopyContainer>
-                            <Button kind={'secondary'} onClick={() => handleCopy(currentBrokerSnippet)}>
+                            <Button
+                                kind="secondary"
+                                onClick={() => void copy(currentBrokerSnippet, {
+                                    toastMessage: 'Copied',
+                                })}
+                            >
                                 Copy
                             </Button>
                         </StreamConnectSnippetCopyContainer>

--- a/app/src/shared/components/StreamPreview/Feed.tsx
+++ b/app/src/shared/components/StreamPreview/Feed.tsx
@@ -5,8 +5,6 @@ import stringifyObject from 'stringify-object'
 import { Tooltip } from '@streamr/streamr-layout'
 
 import { formatDateTime } from '$mp/utils/time'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 import useCopy from '$shared/hooks/useCopy'
 import {COLORS, MAX_BODY_WIDTH, MEDIUM, TABLET} from '$shared/utils/styled'
 import SelectField2 from "$mp/components/SelectField2"
@@ -256,10 +254,8 @@ const UnstyledFeed = ({
             return
         }
 
-        copy(value)
-        Notification.push({
-            title: 'Field data copied to clipboard',
-            icon: NotificationIcon.CHECKMARK,
+        copy(value, {
+            toastMessage: 'Field data copied to clipboard',
         })
     }
 

--- a/app/src/shared/components/StreamPreview/Toolbar.tsx
+++ b/app/src/shared/components/StreamPreview/Toolbar.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import useCopy from '$shared/hooks/useCopy'
 import PrestyledButton from '$shared/components/Button'
 import { SM, LG } from '$shared/utils/styled'
 import Selector from './Selector'
@@ -60,13 +59,6 @@ const Inner = styled.div`
         width: calc(100vw - var(--LiveDataInspectorWidth) - var(--LiveDataMinMargin) - 16px);
     }
 `
-const IfEnoughRoom = styled.div`
-    display: none;
-
-    @media (min-width: 668px) {
-        display: block;
-    }
-`
 
 type Props = {
     className?: string,
@@ -85,7 +77,6 @@ const UnstyledToolbar = ({
     partitions = [],
     streamId
 }: Props) => {
-    const { copy, isCopied } = useCopy()
     return (
         <div className={className}>
             <Lhs>

--- a/app/src/shared/toasts/AbstractToast.tsx
+++ b/app/src/shared/toasts/AbstractToast.tsx
@@ -5,7 +5,7 @@ import { useLayoutEffect, useReducer, useRef, useState } from 'react'
 
 const toastIn = keyframes`
     from {
-        transform: translateX(-100%) translateZ(0);
+        transform: translateX(-100%) translateX(-24px) translateZ(0);
     }
     to {
         transform: translateX(0) translateZ(0);
@@ -14,13 +14,13 @@ const toastIn = keyframes`
 
 const toastSqueeze = keyframes`
     from {
-        transform: translateX(-100%) translateZ(0);
+        transform: translateX(-100%) translateX(-24px) translateZ(0);
     }
     to {
         height: 0;
         margin-top: 0;
         margin-left: 0;
-        transform: translateX(-100%) translateZ(0);
+        transform: translateX(-100%) translateX(-24px) translateZ(0);
     }
 `
 
@@ -29,7 +29,7 @@ const toastOut = keyframes`
         transform: translateX(0) translateZ(0);
     }
     to {
-        transform: translateX(-100%) translateZ(0);
+        transform: translateX(-100%) translateX(-24px) translateZ(0);
     }
 `
 

--- a/app/src/utils/toast.ts
+++ b/app/src/utils/toast.ts
@@ -1,0 +1,28 @@
+import { ComponentProps } from 'react'
+import { toaster } from 'toasterhea'
+import Toast, { ToastType } from '$shared/toasts/Toast'
+import { Layer } from './Layer'
+
+export default function toast(props: ComponentProps<typeof Toast>) {
+    setTimeout(async () => {
+        try {
+            await toaster(Toast, Layer.Toast).pop(props)
+        } catch (_) {
+            // Do nothing
+        }
+    })
+}
+
+export function successToast(props: Omit<ComponentProps<typeof Toast>, 'type'>) {
+    toast({
+        type: ToastType.Success,
+        ...props,
+    })
+}
+
+export function errorToast(props: Omit<ComponentProps<typeof Toast>, 'type'>) {
+    toast({
+        type: ToastType.Warning,
+        ...props,
+    })
+}


### PR DESCRIPTION
So, first things first, popping up a toast has never been easier. From literally anywhere you can now

```tsx
import { successToast } from '$utils/toast'

successToast({ title: 'I am indeed a toast.' })
```

I've integrated it with the `useCopy` hook, so now, if you wanna copy something using the hook you can

```tsx
function Foo() {
    const { copy } = useCopy()

    return (
        <button
            type="button"
            onClick={() => void copy('Bar', {
                toastMessage: 'I am indeed a toast.',
            })}
        >
            Copy!
        </button>
    )
}
```