### PR TITLE
Tweaks and fixes

### DIFF
--- a/app/src/auth/hooks/useAuthController.ts
+++ b/app/src/auth/hooks/useAuthController.ts
@@ -1,6 +1,6 @@
-import {useContext} from "react"
-import {AuthenticationController, AuthenticationControllerContext} from "$auth/authenticationController"
+import { useContext } from 'react'
+import { AuthenticationControllerContext } from '$auth/authenticationController'
 
-export const useAuthController = (): AuthenticationController => {
+export function useAuthController() {
     return useContext(AuthenticationControllerContext)
 }

--- a/app/src/getters/index.ts
+++ b/app/src/getters/index.ts
@@ -1,7 +1,23 @@
+import Web3 from 'web3'
+import { AbiItem } from 'web3-utils'
+import { getConfigForChain } from '$shared/web3/config'
+import projectRegistryAbi from '$shared/web3/abis/projectRegistry.json'
 import getCoreConfig from './getCoreConfig'
 
 export function getGraphUrl() {
     const { theGraphUrl, theHubGraphName } = getCoreConfig()
 
     return `${theGraphUrl}/subgraphs/name/${theHubGraphName}`
+}
+
+export function getProjectRegistryContract(chainId: number, web3: Web3) {
+    const { contracts } = getConfigForChain(chainId)
+
+    const contractAddress = contracts.ProjectRegistryV1 || contracts.ProjectRegistry
+
+    if (!contractAddress) {
+        throw new Error(`No ProjectRegistry contract address found for chain ${chainId}`)
+    }
+
+    return new web3.eth.Contract(projectRegistryAbi as AbiItem[], contractAddress)
 }

--- a/app/src/getters/index.ts
+++ b/app/src/getters/index.ts
@@ -1,0 +1,7 @@
+import getCoreConfig from './getCoreConfig'
+
+export function getGraphUrl() {
+    const { theGraphUrl, theHubGraphName } = getCoreConfig()
+
+    return `${theGraphUrl}/subgraphs/name/${theHubGraphName}`
+}

--- a/app/src/marketplace/components/ProductPage/Terms.tsx
+++ b/app/src/marketplace/components/ProductPage/Terms.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
-import { Optional } from 'utility-types'
-import { Project, TermsOfUse } from '$mp/types/project-types'
+import { TermsOfUse } from '$mp/types/project-types'
 import { DESKTOP, MEDIUM, REGULAR, TABLET } from '$shared/utils/styled'
 
-type Props = {
-    className?: string
-    product: Project
+interface Props {
+    terms: Partial<TermsOfUse>
 }
+
 const termNames = {
     redistribution: 'Redistribution',
     commercialUse: 'Commercial use',
@@ -27,77 +26,86 @@ const getTermStrings = (ids: Array<string>) =>
         return term
     }, '')
 
-const Terms = ({ product }: Props) => {
-    const terms: Optional<TermsOfUse> = product.termsOfUse || {}
+const Terms = ({ terms: { termsUrl = '', termsName = '', ...terms } }: Props) => {
     const entries = Object.entries(terms)
     const permitted = entries.filter((e) => e[1] === true).map((e) => e[0])
     const notPermitted = entries.filter((e) => e[1] === false).map((e) => e[0])
     const permittedStr = useMemo(() => getTermStrings(permitted), [permitted])
     const notPermittedStr = useMemo(() => getTermStrings(notPermitted), [notPermitted])
 
-    if (product == null) {
+    if (!permitted.length && !notPermitted.length && !termsUrl) {
         return null
     }
 
-    return <TermsContainer>
-        <h3>Terms and conditions</h3>
-        <div>
-            <p>
-                <strong>Basic terms</strong>{' '}
-                {permitted.length > 0 && (
-                    <React.Fragment>
-                        {permittedStr}
-                        {permitted.length === 1 ? ' is permitted.' : ' are permitted.'}{' '}
-                    </React.Fragment>
+    return (
+        <TermsContainer>
+            <h3>Terms and conditions</h3>
+            <div>
+                {(permitted.length > 0 || notPermitted.length > 0) && (
+                    <p>
+                        <strong>Basic terms</strong>{' '}
+                        {permitted.length > 0 && (
+                            <React.Fragment>
+                                {permittedStr}
+                                {permitted.length === 1
+                                    ? ' is permitted.'
+                                    : ' are permitted.'}{' '}
+                            </React.Fragment>
+                        )}
+                        {notPermitted.length > 0 && (
+                            <React.Fragment>
+                                {notPermittedStr}
+                                {notPermitted.length === 1 ? ' is not' : ' are not'}
+                            </React.Fragment>
+                        )}
+                        {permitted.length === 0 && ' permitted'}
+                        {notPermitted.length > 0 && '.'}
+                    </p>
                 )}
-                {notPermitted.length > 0 && (
-                    <React.Fragment>
-                        {notPermittedStr}
-                        {notPermitted.length === 1 ? ' is not' : ' are not'}
-                    </React.Fragment>
+                {!!termsUrl && (
+                    <p>
+                        <strong>Detailed terms</strong>{' '}
+                        <strong>
+                            <a href={termsUrl} target="_blank" rel="noopener noreferrer">
+                                {termsName != null && termsName.length > 0
+                                    ? termsName
+                                    : termsUrl}
+                            </a>
+                        </strong>
+                    </p>
                 )}
-                {permitted.length === 0 && ' permitted'}
-                {notPermitted.length > 0 && '.'}
-            </p>
-            {!!terms.termsUrl && (
-                <p>
-                    <strong>Detailed terms</strong>{' '}
-                    <strong>
-                        <a href={terms.termsUrl} target="_blank" rel="noopener noreferrer">
-                            {terms.termsName != null && terms.termsName.length > 0 ? terms.termsName : terms.termsUrl}
-                        </a>
-                    </strong>
-                </p>
-            )}
-        </div>
-    </TermsContainer>
+            </div>
+        </TermsContainer>
+    )
 }
 
 const TermsContainer = styled.div`
-  padding: 30px 24px;
-  background-color: white;
-  border-radius: 16px;
-  margin-top: 16px;
-  font-size: 14px;
-  line-height: 24px;
+    padding: 30px 24px;
+    background-color: white;
+    border-radius: 16px;
+    margin-top: 16px;
+    font-size: 14px;
+    line-height: 24px;
 
-  h3 {
-    font-size: 34px;
-    line-height: 64px;
-    font-weight: ${REGULAR};
-  }
+    h3 {
+        font-size: 34px;
+        line-height: 64px;
+        font-weight: ${REGULAR};
+    }
 
-  strong {
-    font-weight: ${MEDIUM};
-  }
-  @media(${TABLET}) {
-    margin-top: 24px;
-    flex-direction: row;
-    padding: 45px 40px;
-  }
+    strong {
+        font-weight: ${MEDIUM};
+    }
 
-  @media(${DESKTOP}) {
-    padding: 30px 55px;
-  }
+    @media (${TABLET}) {
+        margin-top: 24px;
+        flex-direction: row;
+        padding: 45px 40px;
+    }
+
+    @media (${DESKTOP}) {
+        padding: 30px 55px;
+    }
 `
+
 export default Terms

--- a/app/src/marketplace/components/ProjectTypeChooser/index.tsx
+++ b/app/src/marketplace/components/ProjectTypeChooser/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import openDataImage from '$mp/assets/open-data.png'
 import openDataImage2x from '$mp/assets/open-data@2x.png'
 import paidDataImage from '$mp/assets/paid-data.png'
@@ -165,7 +165,7 @@ export const ProjectTypeChooser: FunctionComponent<{className?: string, onClose:
     const fetchStreams = useFetchStreams()
     const [streamsCount, setStreamsCount] = useState<number>()
 
-    const [selectedProductType, setSelectedProductType] = useState<ProjectTypeEnum>()
+    const [selectedProductType, setSelectedProductType] = useState<ProjectType>()
 
     const link = useMemo<string>(() => {
         if (!selectedProductType) {
@@ -190,7 +190,7 @@ export const ProjectTypeChooser: FunctionComponent<{className?: string, onClose:
             </CloseButton>
         </PageTitleContainer>
         <ProductChoices>
-            <Product onClick={() => setSelectedProductType(ProjectTypeEnum.OPEN_DATA)}>
+            <Product onClick={() => setSelectedProductType(ProjectType.OpenData)}>
                 <ProductTitle>Open data</ProductTitle>
                 <ProductImage>
                     <img src={openDataImage} srcSet={`${openDataImage2x} 2x`} alt="Open Data"/>
@@ -200,12 +200,12 @@ export const ProjectTypeChooser: FunctionComponent<{className?: string, onClose:
                         name={'productType'}
                         size={'large'}
                         label={''}
-                        value={ProjectTypeEnum.OPEN_DATA}
+                        value={ProjectType.OpenData}
                         onChange={setSelectedProductType}
-                        checked={selectedProductType === ProjectTypeEnum.OPEN_DATA}/>
+                        checked={selectedProductType === ProjectType.OpenData}/>
                 </RadioWrap>
             </Product>
-            <Product onClick={() => setSelectedProductType(ProjectTypeEnum.PAID_DATA)}>
+            <Product onClick={() => setSelectedProductType(ProjectType.PaidData)}>
                 <ProductTitle>Paid data</ProductTitle>
                 <ProductImage>
                     <img src={paidDataImage} srcSet={`${paidDataImage2x} 2x`} alt="Paid Data"/>
@@ -215,12 +215,12 @@ export const ProjectTypeChooser: FunctionComponent<{className?: string, onClose:
                         name={'productType'}
                         size={'large'}
                         label={''}
-                        value={ProjectTypeEnum.PAID_DATA}
+                        value={ProjectType.PaidData}
                         onChange={setSelectedProductType}
-                        checked={selectedProductType === ProjectTypeEnum.PAID_DATA}/>
+                        checked={selectedProductType === ProjectType.PaidData}/>
                 </RadioWrap>
             </Product>
-            <Product disabled={true} onClick={() => setSelectedProductType(ProjectTypeEnum.DATA_UNION)} title={'Available soon'}>
+            <Product disabled={true} onClick={() => setSelectedProductType(ProjectType.DataUnion)} title={'Available soon'}>
                 <ProductTitle>Data Union</ProductTitle>
                 <ProductImage>
                     <img src={dataUnionImage} srcSet={`${dataUnionImage2x} 2x`} alt="Data Union"/>
@@ -230,10 +230,10 @@ export const ProjectTypeChooser: FunctionComponent<{className?: string, onClose:
                         name={'productType'}
                         size={'large'}
                         label={''}
-                        value={ProjectTypeEnum.DATA_UNION}
+                        value={ProjectType.DataUnion}
                         onChange={setSelectedProductType}
                         disabled={true}
-                        checked={selectedProductType === ProjectTypeEnum.DATA_UNION}/>
+                        checked={selectedProductType === ProjectType.DataUnion}/>
                 </RadioWrap>
             </Product>
         </ProductChoices>

--- a/app/src/marketplace/containers/ProductController/useEditableProjectActions.ts
+++ b/app/src/marketplace/containers/ProductController/useEditableProjectActions.ts
@@ -6,7 +6,7 @@ import { StreamIdList } from '$shared/types/stream-types'
 import { ValidationContext } from '$mp/containers/ProductController/ValidationContextProvider'
 import { NumberString} from '$shared/types/common-types'
 import { ProjectStateContext } from '$mp/contexts/ProjectStateContext'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import {TimeUnit, timeUnits} from "$shared/utils/timeUnit"
 
 const getPricePerSecond = (isFree: boolean, price: NumberString, timeUnit: TimeUnit, decimals: BN) =>
@@ -22,7 +22,7 @@ export type EditableProjectActions = {
     updateDataUnionChainId: (chainId: number) => void,
     updateSalePoints: (salePoints: Project['salePoints']) => void,
     updateExistingDUAddress: (address: string, touched?: boolean) => void,
-    updateType: (type: ProjectTypeEnum) => void,
+    updateType: (type: ProjectType) => void,
     updateTermsOfUse: (termsOfUse: Project['termsOfUse']) => void,
     updateContactUrl: (url: ContactDetails['url']) => void,
     updateContactEmail: (email: ContactDetails['email']) => void,
@@ -100,7 +100,7 @@ export const useEditableProjectActions = (): EditableProjectActions => {
         [updateState, setTouched],
     )
     const updateType = useCallback<EditableProjectActions['updateType']>(
-        (type: ProjectTypeEnum) => {
+        (type: ProjectType) => {
             updateState({type })
             setTouched('type')
         },

--- a/app/src/marketplace/containers/ProductController/useUserHasAccessToProject.ts
+++ b/app/src/marketplace/containers/ProductController/useUserHasAccessToProject.ts
@@ -1,29 +1,30 @@
-import { hasActiveProjectSubscription, isPaidProject, isProjectOwnedBy } from '$mp/utils/product'
-import { useIsAuthenticated } from '$auth/hooks/useIsAuthenticated'
+import {
+    hasActiveProjectSubscription,
+    isPaidProject,
+    isProjectOwnedBy,
+} from '$mp/utils/product'
 import { useLoadedProject } from '$mp/contexts/LoadedProjectContext'
 import { useAuthController } from '$app/src/auth/hooks/useAuthController'
 
 export const useUserHasAccessToProject = (): boolean => {
     const { loadedProject: project, theGraphProject } = useLoadedProject()
-    const isLoggedIn = useIsAuthenticated()
-    const isPaid = isPaidProject(project)
-    const { currentAuthSession } = useAuthController()
 
-    if (!isPaid) {
-        return true
-    }
+    const { currentAuthSession: { address = undefined } = {} } = useAuthController() || {}
 
-    if (!isLoggedIn) {
+    if (!theGraphProject || !project) {
         return false
     }
 
-    if (currentAuthSession != null && isProjectOwnedBy(theGraphProject, currentAuthSession.address)) {
+    if (!isPaidProject(project)) {
         return true
     }
 
-    if (currentAuthSession != null && hasActiveProjectSubscription(theGraphProject, currentAuthSession.address)) {
-        return true
+    if (!address) {
+        return false
     }
 
-    return false
+    return (
+        isProjectOwnedBy(theGraphProject, address) ||
+        hasActiveProjectSubscription(theGraphProject, address)
+    )
 }

--- a/app/src/marketplace/containers/ProjectEditing/EditProjectPage.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/EditProjectPage.tsx
@@ -15,7 +15,7 @@ import {LoadedProjectContextProvider, useLoadedProject} from "$mp/contexts/Loade
 import PrestyledLoadingIndicator from "$shared/components/LoadingIndicator"
 import {MarketplaceLoadingView} from "$mp/containers/ProjectPage/MarketplaceLoadingView"
 import {getProjectTitleForEditor} from "$mp/containers/ProjectPage/utils"
-import { InactiveProjectLinkTabs } from "../ProjectPage/utils"
+import ProjectLinkTabs from '$app/src/pages/ProjectPage/ProjectLinkTabs'
 
 const UnstyledEditProjectPage: FunctionComponent = () => {
     const {state: project} = useContext(ProjectStateContext)
@@ -46,7 +46,7 @@ const UnstyledEditProjectPage: FunctionComponent = () => {
         <MarketplaceHelmet title={'Edit project'}/>
         <DetailsPageHeader
             pageTitle={pageTitle}
-            rightComponent={<InactiveProjectLinkTabs />}
+            rightComponent={<ProjectLinkTabs />}
         />
         <LoadingIndicator loading={publishInProgress}/>
         <ProjectEditor nonEditableSalePointChains={nonEditableSalePointChains}/>

--- a/app/src/marketplace/containers/ProjectEditing/NewProjectPage.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/NewProjectPage.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import qs from 'query-string'
 import '$mp/types/project-types'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import Layout from '$shared/components/Layout'
 import { MarketplaceHelmet } from '$shared/components/Helmet'
 import { DetailsPageHeader } from '$shared/components/DetailsPageHeader'
@@ -41,8 +41,8 @@ const UnstyledNewProjectPage = ({ className }: Props) => {
     })
 
     useEffect(() => {
-        const typeIsValid = Object.values(ProjectTypeEnum).includes(type as ProjectTypeEnum)
-        updateType( typeIsValid ? type as ProjectTypeEnum : ProjectTypeEnum.OPEN_DATA)
+        const typeIsValid = Object.values(ProjectType).includes(type as ProjectType)
+        updateType( typeIsValid ? type as ProjectType : ProjectType.OpenData)
     }, [type, updateType])
 
     useEffect(() => {

--- a/app/src/marketplace/containers/ProjectEditing/NewProjectPage.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/NewProjectPage.tsx
@@ -22,8 +22,8 @@ import {
 } from '$mp/containers/ProjectEditing/ProjectController'
 import PrestyledLoadingIndicator from "$shared/components/LoadingIndicator"
 import {getProjectTitleForEditor} from "$mp/containers/ProjectPage/utils"
+import ProjectLinkTabs from '$app/src/pages/ProjectPage/ProjectLinkTabs'
 import { useEditableProjectActions } from '../ProductController/useEditableProjectActions'
-import { InactiveProjectLinkTabs } from '../ProjectPage/utils'
 
 type Props = {
     className?: string | null | undefined
@@ -57,7 +57,7 @@ const UnstyledNewProjectPage = ({ className }: Props) => {
         <MarketplaceHelmet title={'Create a new project'}/>
         <DetailsPageHeader
             pageTitle={pageTitle}
-            rightComponent={<InactiveProjectLinkTabs />}
+            rightComponent={<ProjectLinkTabs />}
         />
         <LoadingIndicator loading={publishInProgress}/>
         <ProjectEditor/>

--- a/app/src/marketplace/containers/ProjectEditing/ProjectController.test.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/ProjectController.test.tsx
@@ -9,7 +9,7 @@ import * as validationCtx from "$mp/containers/ProductController/ValidationConte
 import {createProject, SmartContractProjectCreate, updateProject} from "$app/src/services/projects"
 import {useProjectState} from "$mp/contexts/ProjectStateContext"
 import Notification from '$shared/utils/Notification'
-import {ProjectTypeEnum} from "$mp/utils/constants"
+import { ProjectType } from '$shared/types'
 import {NotificationIcon} from "$shared/utils/constants"
 import {PersistOperation} from "$shared/types/common-types"
 import {useProjectEditorStore} from "$mp/containers/ProjectEditing/proejctEditor.state"
@@ -84,7 +84,7 @@ const PROJECT_STUB: Project = {
         twitter: 'https://twitter.com',
         telegram: 'https://telegram.com'
     },
-    type: ProjectTypeEnum.PAID_DATA,
+    type: ProjectType.PaidData,
     salePoints: {
         'polygon': {
             chainId: 1,

--- a/app/src/marketplace/containers/ProjectEditing/ProjectController.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/ProjectController.tsx
@@ -9,7 +9,7 @@ import {
 } from '$mp/containers/ProductController/ValidationContextProvider'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import { postImage } from '$app/src/services/images'
 import {
     createProject,
@@ -105,7 +105,7 @@ export const useProjectController = (): ProjectController => {
             id: id || randomHex(32),
             minimumSubscriptionInSeconds: 0,
             streams: [...project.streams],
-            paymentDetails: project.type === ProjectTypeEnum.PAID_DATA ? Object.values(project.salePoints).map((salePoint) => {
+            paymentDetails: project.type === ProjectType.PaidData ? Object.values(project.salePoints).map((salePoint) => {
                 return {
                     chainId: salePoint.chainId,
                     beneficiaryAddress: salePoint.beneficiaryAddress,
@@ -127,7 +127,7 @@ export const useProjectController = (): ProjectController => {
         let transactionsToastNotification: Notification | null = null
         const projectContractData: SmartContractProjectCreate = {
             ...(await getSmartContractProject()),
-            isPublicPurchasable: project.type !== ProjectTypeEnum.OPEN_DATA,
+            isPublicPurchasable: project.type !== ProjectType.OpenData,
         }
 
         setPublishInProgress(true)
@@ -213,10 +213,10 @@ export const useProjectController = (): ProjectController => {
     const create = useCallback<ProjectController['create']>(async() => {
         if (checkValidationErrors()) {
             switch (project.type) {
-                case ProjectTypeEnum.PAID_DATA:
-                case ProjectTypeEnum.OPEN_DATA:
+                case ProjectType.PaidData:
+                case ProjectType.OpenData:
                     return await createNewProject()
-                case ProjectTypeEnum.DATA_UNION:
+                case ProjectType.DataUnion:
                     return await createNewDataUnion()
             }
         }
@@ -226,10 +226,10 @@ export const useProjectController = (): ProjectController => {
     const update = useCallback<ProjectController['update']>(async () => {
         if (checkValidationErrors()) {
             switch (project.type) {
-                case ProjectTypeEnum.PAID_DATA:
-                case ProjectTypeEnum.OPEN_DATA:
+                case ProjectType.PaidData:
+                case ProjectType.OpenData:
                     return await updateExistingProject()
-                case ProjectTypeEnum.DATA_UNION:
+                case ProjectType.DataUnion:
                     return await updateExistingDataUnion()
             }
         }

--- a/app/src/marketplace/containers/ProjectEditing/ProjectEditor.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/ProjectEditor.tsx
@@ -8,7 +8,7 @@ import ProjectDescription from '$mp/containers/ProjectEditing/ProjectDescription
 import { ProjectDetails } from '$mp/containers/ProjectEditing/ProjectDetails'
 import { WhiteBox } from '$shared/components/WhiteBox'
 import { ProjectStateContext } from '$mp/contexts/ProjectStateContext'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import { StreamSelector } from '$mp/containers/ProjectEditing/StreamSelector'
 import { TermsOfUse } from '$mp/containers/ProjectEditing/TermsOfUse'
 import { SalePointSelector } from '$mp/containers/ProjectEditing/SalePointSelector/SalePointSelector'
@@ -46,12 +46,12 @@ export const ProjectEditor: FunctionComponent<ProjectEditorProps> = ({nonEditabl
             <ProjectDescription/>
             <ProjectDetails/>
         </ProjectHeroContainer>
-        {project.type === ProjectTypeEnum.PAID_DATA &&
+        {project.type === ProjectType.PaidData &&
             <WhiteBox>
                 <SalePointSelector nonEditableSalePointChains={nonEditableSalePointChains}/>
             </WhiteBox>
         }
-        {project.type === ProjectTypeEnum.DATA_UNION && <>
+        {project.type === ProjectType.DataUnion && <>
             <WhiteBox>
                 <DataUnionChainSelector/>
             </WhiteBox>

--- a/app/src/marketplace/containers/ProjectEditing/PublishModal.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/PublishModal.tsx
@@ -20,7 +20,7 @@ import useSwitchChain from '$shared/hooks/useSwitchChain'
 import { getChainIdFromApiString } from '$shared/utils/chains'
 import getNativeTokenName from '$shared/utils/nativeToken'
 import { PublishMode } from '$mp/containers/ProjectEditing/publishMode'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 
 type Props = {
     product: Project
@@ -33,7 +33,7 @@ export const PublishOrUnpublishModal = ({ product, api }: Props) => {
     publishRef.current = publish
     const isMounted = useIsMounted()
     // TODO - check if this chainId value assignment is correct
-    const chainId = (product.type === ProjectTypeEnum.DATA_UNION) ? product.dataUnionChainId : getChainIdFromApiString('polygon')
+    const chainId = (product.type === ProjectType.DataUnion) ? product.dataUnionChainId : getChainIdFromApiString('polygon')
     const nativeTokenName = getNativeTokenName(chainId)
     const [queue, setQueue] = useState(undefined)
     const [mode, setMode] = useState(null)

--- a/app/src/marketplace/containers/ProjectPage/Description.tsx
+++ b/app/src/marketplace/containers/ProjectPage/Description.tsx
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom'
 import {Project, SalePoint} from '$mp/types/project-types'
 import { REGULAR, TABLET } from '$shared/utils/styled'
 import Button from '$shared/components/Button'
-import { ProjectTypeEnum, projectTypeNames } from '$mp/utils/constants'
+import { projectTypeNames } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import PaymentRate from '$mp/components/PaymentRate'
 import { formatChainName } from '$shared/utils/chains'
 import useModal from '$shared/hooks/useModal'
@@ -25,11 +26,11 @@ const Description: FunctionComponent<{project: Project}> = ({project}) => {
                 <p>
                     <span>
                         The streams in this {projectTypeNames[project.type]}
-                        {project.type === ProjectTypeEnum.OPEN_DATA ? ' are public and ' : ''} can be accessed for&nbsp;
+                        {project.type === ProjectType.OpenData ? ' are public and ' : ''} can be accessed for&nbsp;
                     </span>
 
                     <strong>
-                        {project.type === ProjectTypeEnum.OPEN_DATA ? (
+                        {project.type === ProjectType.OpenData ? (
                             'free'
                         ) : (
                             <PaymentRate
@@ -41,7 +42,7 @@ const Description: FunctionComponent<{project: Project}> = ({project}) => {
                             />
                         )}
                     </strong>
-                    {project.type !== ProjectTypeEnum.OPEN_DATA && (
+                    {project.type !== ProjectType.OpenData && (
                         <>
                             <span> on </span>
                             <strong>{formatChainName(firstSalePointChainName)}</strong>
@@ -54,12 +55,12 @@ const Description: FunctionComponent<{project: Project}> = ({project}) => {
                         </>
                     )}
                 </p>
-                {project.type === ProjectTypeEnum.OPEN_DATA && (
+                {project.type === ProjectType.OpenData && (
                     <Button tag={Link} to={routes.projects.connect({ id: project.id })}>
                         Connect
                     </Button>
                 )}
-                {project.type !== ProjectTypeEnum.OPEN_DATA && (
+                {project.type !== ProjectType.OpenData && (
                     <Button onClick={() => purchaseDialog.open({ projectId: project.id })}>Get Access</Button>
                 )}
                 <PurchaseModal />

--- a/app/src/marketplace/containers/ProjectPage/Page.tsx
+++ b/app/src/marketplace/containers/ProjectPage/Page.tsx
@@ -47,7 +47,7 @@ const ProjectDetailsPage: FunctionComponent = () => {
                     />
                 )}*/}
 
-                <Terms product={project} />
+                <Terms terms={project?.termsOfUse || {}} />
             </ProjectPageContainer>
         </ProjectPage>
     )

--- a/app/src/marketplace/containers/ProjectPage/Page.tsx
+++ b/app/src/marketplace/containers/ProjectPage/Page.tsx
@@ -36,7 +36,7 @@ const ProjectDetailsPage: FunctionComponent = () => {
             <ProjectPageContainer>
                 <ProjectHero2 project={project}/>
                 <Description project={project} />
-                <Streams project={project} />
+                <Streams streams={project?.streams || []} />
                 {/*{isDataUnion && (
                     <DataUnionStats
                         showDeploying={!isDuDeployed}

--- a/app/src/marketplace/containers/ProjectPage/ProjectConnectPage.tsx
+++ b/app/src/marketplace/containers/ProjectPage/ProjectConnectPage.tsx
@@ -9,8 +9,8 @@ import { Connect } from '$mp/containers/ProjectPage/Connect'
 import styles from '$shared/components/Layout/layout.pcss'
 import {LoadedProjectContextProvider, useLoadedProject} from "$mp/contexts/LoadedProjectContext"
 import {ProjectPageTitle} from "$mp/components/PageTitle"
+import ProjectLinkTabs from '$app/src/pages/ProjectPage/ProjectLinkTabs'
 import routes from "$routes"
-import { ProjectLinkTabs } from './utils'
 
 const ProjectConnect: FunctionComponent = () => {
     const {loadedProject: project} = useLoadedProject()

--- a/app/src/marketplace/containers/ProjectPage/ProjectLiveDataPage.tsx
+++ b/app/src/marketplace/containers/ProjectPage/ProjectLiveDataPage.tsx
@@ -9,8 +9,8 @@ import { GetAccess } from '$mp/components/GetAccess/GetAccess'
 import { ProjectPageTitle } from '$mp/components/PageTitle'
 import { useUserHasAccessToProject } from '$mp/containers/ProductController/useUserHasAccessToProject'
 import { StreamPreview } from '$shared/components/StreamPreview'
+import ProjectLinkTabs from '$app/src/pages/ProjectPage/ProjectLinkTabs'
 import routes from '$routes'
-import { ProjectLinkTabs } from './utils'
 
 const ProjectLiveData: FunctionComponent = () => {
     const { loadedProject: project } = useLoadedProject()

--- a/app/src/marketplace/containers/ProjectPage/Streams.tsx
+++ b/app/src/marketplace/containers/ProjectPage/Streams.tsx
@@ -19,15 +19,19 @@ const StreamsContainer = styled.div`
     }
 `
 
-const Streams: FunctionComponent<{ project: Project }> = ({ project }) => {
+interface Props {
+    streams: string[]
+}
+
+export default function Streams({ streams: streamsProp }: Props) {
     const [streams, setStreams] = useState<Stream[]>([])
     const [streamStats, setStreamStats] = useState<Record<StreamID, IndexerStream>>({})
     const [offset, setOffset] = useState(INITIAL_OFFSET)
     const loadStreams = useLoadProductStreamsCallback({ setProductStreams: setStreams })
 
     useEffect(() => {
-        loadStreams(project.streams.slice(0, INITIAL_OFFSET))
-    }, [project.streams, loadStreams])
+        loadStreams(streamsProp.slice(0, INITIAL_OFFSET))
+    }, [streamsProp, loadStreams])
 
     useEffect(() => {
         const getStreamStats = async () => {
@@ -47,12 +51,12 @@ const Streams: FunctionComponent<{ project: Project }> = ({ project }) => {
         getStreamStats()
     }, [streams])
 
-    const hasMoreResults = useMemo(() => offset < project.streams.length, [offset, project.streams])
+    const hasMoreResults = useMemo(() => offset < streamsProp.length, [offset, streamsProp])
 
     const onLoadMore = useCallback(() => {
-        loadStreams(project.streams.slice(offset, offset + PAGE_SIZE))
+        loadStreams(streamsProp.slice(offset, offset + PAGE_SIZE))
         setOffset(offset + PAGE_SIZE)
-    }, [offset, setOffset, loadStreams, project.streams])
+    }, [offset, setOffset, loadStreams, streamsProp])
 
     return (
         <>
@@ -70,5 +74,3 @@ const Streams: FunctionComponent<{ project: Project }> = ({ project }) => {
         </>
     )
 }
-
-export default Streams

--- a/app/src/marketplace/containers/ProjectPage/index.tsx
+++ b/app/src/marketplace/containers/ProjectPage/index.tsx
@@ -7,11 +7,11 @@ import { MarketplaceLoadingView } from '$mp/containers/ProjectPage/MarketplaceLo
 import styles from '$shared/components/Layout/layout.pcss'
 import {LoadedProjectContextProvider, useLoadedProject} from "$mp/contexts/LoadedProjectContext"
 import {ProjectPageTitle} from "$mp/components/PageTitle"
+import ProjectLinkTabs from '$app/src/pages/ProjectPage/ProjectLinkTabs'
 import routes from '$routes'
 import WhitelistRequestAccessModal from './WhitelistRequestAccessModal'
 import PurchaseModal from './PurchaseModal'
 import Page from './Page'
-import { ProjectLinkTabs } from './utils'
 
 const ProjectPage = () => {
     const {loadedProject: project} = useLoadedProject()

--- a/app/src/marketplace/containers/ProjectPage/utils.tsx
+++ b/app/src/marketplace/containers/ProjectPage/utils.tsx
@@ -1,11 +1,7 @@
 import React, { ReactNode } from 'react'
 import styled from "styled-components"
-import { Link, useLocation } from 'react-router-dom'
 import { Project } from '$mp/types/project-types'
-import Tabs, { Tab } from '$shared/components/Tabs'
-import isPreventable from '$app/src/utils/isPreventable'
-import {mapProjectTypeName} from "$mp/utils/project-mapper"
-import routes from '$routes'
+import { mapProjectTypeName } from "$mp/utils/project-mapper"
 
 const ProjectTitlePart = styled.strong`
   text-overflow: ellipsis;
@@ -34,70 +30,5 @@ export const getProjectTitleForEditor = (project: Project): ReactNode => {
                 <strong>&nbsp;{project.creator} </strong>
             </>
         )
-    )
-}
-
-export function ProjectLinkTabs({ projectId }: { projectId: string | undefined }) {
-    const { pathname } = useLocation()
-
-    if (!projectId) {
-        return <></>
-    }
-
-    return (
-        <Tabs selection={pathname}>
-            <Tab
-                id="overview"
-                tag={Link}
-                to={routes.projects.overview({ id: projectId })}
-                selected="to"
-            >
-                Project overview
-            </Tab>
-            <Tab
-                id="connect"
-                tag={Link}
-                to={routes.projects.connect({ id: projectId })}
-                selected="to"
-            >
-                Connect
-            </Tab>
-            <Tab
-                id="liveData"
-                tag={Link}
-                to={routes.projects.liveData({ id: projectId })}
-                selected="to"
-            >
-                Live data
-            </Tab>
-        </Tabs>
-    )
-}
-
-export function InactiveProjectLinkTabs() {
-    const { pathname } = useLocation()
-
-    return (
-        <Tabs>
-            <Tab
-                id="overview"
-                tag={Link}
-                selected
-                to={pathname}
-                onClick={(e: unknown) => {
-                    if (isPreventable(e)) {
-                        e.preventDefault()
-                    }
-                }}
-            >
-                Project overview
-            </Tab>
-            <Tab id="connect" disabled>
-                Connect
-            </Tab>
-            <Tab id="liveData" disabled>
-                Live data
-            </Tab>
-        </Tabs>
     )
 }

--- a/app/src/marketplace/types/project-types.ts
+++ b/app/src/marketplace/types/project-types.ts
@@ -1,7 +1,7 @@
 import BN from 'bignumber.js'
 import { $ElementType, $Keys, $Values } from 'utility-types'
 import { projectStates } from '$shared/utils/constants'
-import { ProjectTypeEnum, projectTypes } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import { StreamIdList } from '$shared/types/stream-types'
 import { NumberString, PaymentCurrency } from '$shared/types/common-types'
 import { Address } from '$shared/types/web3-types'
@@ -11,7 +11,6 @@ import { CategoryId } from './category-types'
 export type ProjectId = string
 export type ChainName = string
 export type ProjectState = $Keys<typeof projectStates>
-export type ProjectType = $Values<typeof projectTypes>
 
 export type SalePoint = {
     chainId: number,
@@ -46,7 +45,7 @@ export type Project = {
     imageIpfsCid?: string | null | undefined
     newImageToUpload?: File | null | undefined
     streams: StreamIdList
-    type: ProjectTypeEnum
+    type: ProjectType
     termsOfUse: TermsOfUse
     contact: ContactDetails | null | undefined
     creator: string

--- a/app/src/marketplace/utils/constants.ts
+++ b/app/src/marketplace/utils/constants.ts
@@ -1,3 +1,4 @@
+import { ProjectType } from '$shared/types'
 /*
     These are all type
     {
@@ -20,23 +21,8 @@ export const purchaseFlowSteps = {
 export const productListPageSize = 20
 export const searchCharMax = 250
 
-/**
- * @deprecated
- */
-export const projectTypes = {
-    NORMAL: 'NORMAL',
-    DATAUNION: 'DATAUNION',
-}
-
-export const projectTypeNames: Record<ProjectTypeEnum, string> = {
-    OPEN_DATA: 'open data project',
-    PAID_DATA: 'paid data project',
-    DATA_UNION: 'Data Union'
-}
-
-// Hub project types
-export enum ProjectTypeEnum {
-    OPEN_DATA = 'OPEN_DATA',
-    PAID_DATA = 'PAID_DATA',
-    DATA_UNION = 'DATA_UNION'
+export const projectTypeNames: Record<ProjectType, string> = {
+    [ProjectType.OpenData]: 'open data project',
+    [ProjectType.PaidData]: 'paid data project',
+    [ProjectType.DataUnion]: 'Data Union'
 }

--- a/app/src/marketplace/utils/empty-project.ts
+++ b/app/src/marketplace/utils/empty-project.ts
@@ -1,11 +1,11 @@
 import { Project } from '$mp/types/project-types'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 
 export class EmptyProject implements Project {
     id: undefined
     name: undefined
     adminFee = undefined
-    type = ProjectTypeEnum.OPEN_DATA
+    type = ProjectType.OpenData
     contact = {}
     imageUrl = undefined
     streams = []

--- a/app/src/marketplace/utils/product.ts
+++ b/app/src/marketplace/utils/product.ts
@@ -14,17 +14,16 @@ import { getPrefixedHexString, getUnprefixedHexString, isValidHexString } from '
 
 export const isPaidProject = (project: Project): boolean => project.type !== ProjectTypeEnum.OPEN_DATA
 
-export const isProjectOwnedBy = (project: TheGraphProject, address: string): boolean => {
-    const { canGrant = false } = project.permissions.find((p) => p.userAddress.toLowerCase() === address.toLowerCase()) || {}
+export const isProjectOwnedBy = ({ permissions }: Pick<TheGraphProject, 'permissions'>, address: string) => {
+    const { canGrant = false } = permissions.find((p) => p.userAddress.toLowerCase() === address.toLowerCase()) || {}
 
     return !!canGrant
 }
 
-export const hasActiveProjectSubscription = (project: TheGraphProject, address: string): boolean => {
-    const { endTimestamp = '0' } = project.subscriptions.find((s) => s.userAddress.toLowerCase() === address.toLowerCase()) || {}
+export const hasActiveProjectSubscription = ({ subscriptions }: Pick<TheGraphProject, 'subscriptions'>, address: string): boolean => {
+    const { endTimestamp = '0' } = subscriptions.find((s) => s.userAddress.toLowerCase() === address.toLowerCase()) || {}
 
-    return Number.parseInt(endTimestamp, 10) * 1000 >= Date.now()
-}
+    return Number.parseInt(endTimestamp, 10) * 1000 >= Date.now()}
 
 export const isDataUnionProject = (project: TheGraphProject): boolean => {
     if (project != null && project.metadata != null) {

--- a/app/src/marketplace/utils/product.ts
+++ b/app/src/marketplace/utils/product.ts
@@ -15,19 +15,15 @@ import { getPrefixedHexString, getUnprefixedHexString, isValidHexString } from '
 export const isPaidProject = (project: Project): boolean => project.type !== ProjectTypeEnum.OPEN_DATA
 
 export const isProjectOwnedBy = (project: TheGraphProject, address: string): boolean => {
-    const userPermissions = project.permissions.find((p) => p.userAddress.toLowerCase() === address.toLowerCase())
-    if (userPermissions != null && userPermissions.canGrant === true) {
-        return true
-    }
-    return false
+    const { canGrant = false } = project.permissions.find((p) => p.userAddress.toLowerCase() === address.toLowerCase()) || {}
+
+    return !!canGrant
 }
 
 export const hasActiveProjectSubscription = (project: TheGraphProject, address: string): boolean => {
-    const userSubscription = project.subscriptions.find((s) => s.userAddress.toLowerCase() === address.toLowerCase())
-    if (userSubscription != null && Number.parseInt(userSubscription.endTimestamp) * 1000 >= Date.now()) {
-        return true
-    }
-    return false
+    const { endTimestamp = '0' } = project.subscriptions.find((s) => s.userAddress.toLowerCase() === address.toLowerCase()) || {}
+
+    return Number.parseInt(endTimestamp, 10) * 1000 >= Date.now()
 }
 
 export const isDataUnionProject = (project: TheGraphProject): boolean => {

--- a/app/src/marketplace/utils/project-mapper.test.ts
+++ b/app/src/marketplace/utils/project-mapper.test.ts
@@ -1,7 +1,7 @@
 import BN from "bn.js"
 import {TheGraphPaymentDetails, TheGraphProject} from "$app/src/services/projects"
 import {mapGraphProjectToDomainModel, mapSalePoints} from "$mp/utils/project-mapper"
-import {ProjectTypeEnum} from "$mp/utils/constants"
+import { ProjectType } from '$shared/types'
 import getCoreConfig from '$app/src/getters/getCoreConfig'
 
 const stubChainName = 'localChain'
@@ -77,7 +77,7 @@ describe('projectMapper', () => {
 
             expect(model).toMatchObject({
                 id: stubGraphModel.id,
-                type: ProjectTypeEnum.PAID_DATA,
+                type: ProjectType.PaidData,
                 name: stubGraphModel.metadata.name,
                 description: stubGraphModel.metadata.description,
                 creator: stubGraphModel.metadata.creator,

--- a/app/src/marketplace/utils/project-mapper.ts
+++ b/app/src/marketplace/utils/project-mapper.ts
@@ -1,7 +1,7 @@
 import BN from "bignumber.js"
 import {TheGraphPaymentDetails, TheGraphProject} from "$app/src/services/projects"
 import {ChainName, Project, SalePoint} from "$mp/types/project-types"
-import {ProjectTypeEnum} from "$mp/utils/constants"
+import { ProjectType } from '$shared/types'
 import {getConfigForChain} from "$shared/web3/config"
 import {getMostRelevantTimeUnit} from "$mp/utils/price"
 import {getTokenInformation} from "$mp/utils/web3"
@@ -43,11 +43,11 @@ export const mapGraphProjectToDomainModel = async (graphProject: TheGraphProject
     }
 }
 
-export const mapProjectType = (graphProject: TheGraphProject): ProjectTypeEnum => {
+export const mapProjectType = (graphProject: TheGraphProject): ProjectType => {
     // TODO when the TheGraphProject will have field which determines if it's a Data Union - implement a check here
     return graphProject.paymentDetails.length === 1 && graphProject.paymentDetails[0].pricePerSecond == '0'
-        ? ProjectTypeEnum.OPEN_DATA
-        : ProjectTypeEnum.PAID_DATA
+        ? ProjectType.OpenData
+        : ProjectType.PaidData
 }
 
 export const mapSalePoints = async (paymentDetails: TheGraphPaymentDetails[]): Promise<Record<ChainName, SalePoint>> => {
@@ -69,13 +69,13 @@ export const mapSalePoints = async (paymentDetails: TheGraphPaymentDetails[]): P
     return salePoints
 }
 
-export const mapProjectTypeName = (projectType: ProjectTypeEnum): string => {
+export const mapProjectTypeName = (projectType: ProjectType): string => {
     switch (projectType) {
-        case ProjectTypeEnum.OPEN_DATA:
+        case ProjectType.OpenData:
             return 'Open data'
-        case ProjectTypeEnum.DATA_UNION:
+        case ProjectType.DataUnion:
             return 'Data Union'
-        case ProjectTypeEnum.PAID_DATA:
+        case ProjectType.PaidData:
             return 'Paid data'
         default:
             return 'Project'

--- a/app/src/marketplace/utils/web3.ts
+++ b/app/src/marketplace/utils/web3.ts
@@ -178,11 +178,11 @@ export const getTokenInformation = async (
         }
 
         const name = await contract.name().call()
-        const decimals = await contract.decimals().call()
+        const decimals: number | string = await contract.decimals().call()
         const infoObj: TokenInformation = {
             symbol,
             name,
-            decimals,
+            decimals: Number.parseInt(`${decimals}`, 10),
         }
         tokenInformationCache[cacheKey] = infoObj
         return infoObj

--- a/app/src/pages/ProjectPage/ProjectLinkTabs.tsx
+++ b/app/src/pages/ProjectPage/ProjectLinkTabs.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import isPreventable from '$utils/isPreventable'
+import Tabs, { Tab } from '$shared/components/Tabs'
+import routes from '$routes'
+
+export default function ProjectLinkTabs({
+    projectId,
+    disabled = false,
+}: {
+    projectId?: string
+    disabled?: boolean
+}) {
+    const { pathname } = useLocation()
+
+    if (!projectId || disabled) {
+        return (
+            <Tabs>
+                <Tab
+                    id="overview"
+                    tag={Link}
+                    selected
+                    to={pathname}
+                    onClick={(e: unknown) => {
+                        if (isPreventable(e)) {
+                            e.preventDefault()
+                        }
+                    }}
+                >
+                    Project overview
+                </Tab>
+                <Tab id="connect" disabled>
+                    Connect
+                </Tab>
+                <Tab id="liveData" disabled>
+                    Live data
+                </Tab>
+            </Tabs>
+        )
+    }
+
+    return (
+        <Tabs selection={pathname}>
+            <Tab
+                id="overview"
+                tag={Link}
+                to={routes.projects.overview({ id: projectId })}
+                selected="to"
+            >
+                Project overview
+            </Tab>
+            <Tab
+                id="connect"
+                tag={Link}
+                to={routes.projects.connect({ id: projectId })}
+                selected="to"
+            >
+                Connect
+            </Tab>
+            <Tab
+                id="liveData"
+                tag={Link}
+                to={routes.projects.liveData({ id: projectId })}
+                selected="to"
+            >
+                Live data
+            </Tab>
+        </Tabs>
+    )
+}

--- a/app/src/services/projects.ts
+++ b/app/src/services/projects.ts
@@ -414,9 +414,9 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 export const waitUntilProjectPurchased = async (id: string, timeoutSeconds = 60) => {
     const waitBetweenChecks = 3000
     const chainId = getProjectRegistryChainId()
-    const contract = getProjectRegistryContract(chainId, getPublicWeb3(chainId))
-
     const web3 = getPublicWeb3(chainId)
+    const contract = getProjectRegistryContract(chainId, web3)
+
     const myAddress = await getDefaultWeb3Account()
     const currentBlock = await web3.eth.getBlockNumber() - 10 // take a couple of blocks back to be sure
 

--- a/app/src/services/projects.ts
+++ b/app/src/services/projects.ts
@@ -12,11 +12,7 @@ import {ProjectId} from "$mp/types/project-types"
 import address0 from "$utils/address0"
 import getPublicWeb3 from '../utils/web3/getPublicWeb3'
 import getDefaultWeb3Account from '../utils/web3/getDefaultWeb3Account'
-
-const getGraphUrl = () => {
-    const { theGraphUrl, theHubGraphName } = getCoreConfig()
-    return `${theGraphUrl}/subgraphs/name/${theHubGraphName}`
-}
+import { getGraphUrl } from '../getters'
 
 const getProjectRegistryChainId = () => {
     const { projectsChain } = getCoreConfig()

--- a/app/src/shared/components/Tabs.tsx
+++ b/app/src/shared/components/Tabs.tsx
@@ -120,7 +120,7 @@ const Root = styled.div`
     overflow: hidden;
 `
 
-const Trolley = styled.div<{ $selected?: boolean }>`
+const Trolley = styled.div<{ $selected?: boolean; $animated?: boolean }>`
     height: 100%;
     display: flex;
     align-items: center;
@@ -131,14 +131,19 @@ const Trolley = styled.div<{ $selected?: boolean }>`
     left: 0;
     padding: 0 20px;
     white-space: nowrap;
-    transition: 200ms ease-out;
-    transition-property: visibility, opacity;
     left: 50%;
     transform: translateX(-50%);
     min-width: 0;
     width: 100%;
     justify-content: center;
     text-align: center;
+
+    ${({ $animated = false }) =>
+        $animated &&
+        css`
+            transition: 200ms ease-out;
+            transition-property: visibility, opacity;
+        `}
 
     ${({ $selected = false }) =>
         $selected &&
@@ -355,7 +360,7 @@ export default function Tabs({
                     }}
                 >
                     {tabs.map(({ id, children }) => (
-                        <Trolley key={id} $selected={id === selectedId}>
+                        <Trolley key={id} $selected={id === selectedId} $animated={animated}>
                             <ItemContent $truncate={spreadEvenly}>{children}</ItemContent>
                         </Trolley>
                     ))}

--- a/app/src/shared/stores/streamAbilities.ts
+++ b/app/src/shared/stores/streamAbilities.ts
@@ -75,12 +75,12 @@ const useStreamAbilitiesStore = create<Store>((set, get) => {
         async fetchPermission(streamId, account, permission, streamrClient) {
             const pkey = permissionKey(streamId, account, permission)
 
-            try {
-                if (get().fetching[pkey]) {
-                    // Already fetching, skip.
-                    return
-                }
+            if (get().fetching[pkey]) {
+                // Already fetching, skip.
+                return
+            }
 
+            try {
                 toggleFetching(streamId, account, permission, true)
 
                 let stream: Stream | undefined

--- a/app/src/shared/types/index.ts
+++ b/app/src/shared/types/index.ts
@@ -1,0 +1,5 @@
+export enum ProjectType {
+    OpenData = 'OPEN_DATA',
+    PaidData = 'PAID_DATA',
+    DataUnion = 'DATA_UNION'
+}

--- a/app/test/unit/utils/product.test.ts
+++ b/app/test/unit/utils/product.test.ts
@@ -1,19 +1,19 @@
 import BN from 'bignumber.js'
 import * as all from '$mp/utils/product'
 import { Project, SalePoint } from '$mp/types/project-types'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 
 describe('product utils', () => {
     describe('isPaidProduct', () => {
         it('detects a free product', () => {
             const product = {
-                type: ProjectTypeEnum.OPEN_DATA
+                type: ProjectType.OpenData
             } as Project
             expect(all.isPaidProject(product)).toBe(false)
         })
         it('detects a paid product', () => {
             const product = {
-                type: ProjectTypeEnum.PAID_DATA
+                type: ProjectType.PaidData
             } as Project
             expect(all.isPaidProject(product)).toBe(true)
         })
@@ -22,7 +22,7 @@ describe('product utils', () => {
         it('detects data union product from object', () => {
             const product1 = {
                 id: 'text',
-                type: 'DATAUNION',
+                type: ProjectType.DataUnion,
             } as any
             expect(all.isDataUnionProduct(product1)).toBe(true)
             const product2 = {
@@ -35,7 +35,7 @@ describe('product utils', () => {
             expect(all.isDataUnionProduct({} as any)).toBe(false)
         })
         it('detects data union product from value', () => {
-            expect(all.isDataUnionProduct('DATAUNION')).toBe(true)
+            expect(all.isDataUnionProduct(ProjectType.DataUnion)).toBe(true)
             expect(all.isDataUnionProduct('NORMAL')).toBe(false)
         })
         it('detects data union product from empty value', () => {
@@ -167,7 +167,7 @@ describe('product utils', () => {
         it('validates empty product free data product', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.OPEN_DATA,
+                    type: ProjectType.OpenData,
                 } as Project),
             ).toStrictEqual({
                 name: true,
@@ -180,7 +180,7 @@ describe('product utils', () => {
         it('validates empty product paid data product', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.PAID_DATA,
+                    type: ProjectType.PaidData,
                 } as Project),
             ).toStrictEqual({
                 name: true,
@@ -194,7 +194,7 @@ describe('product utils', () => {
         it('validates empty product paid data union', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.DATA_UNION,
+                    type: ProjectType.DataUnion,
                 } as Project),
             ).toStrictEqual({
                 name: true,
@@ -210,7 +210,7 @@ describe('product utils', () => {
         it('validates name & description', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.OPEN_DATA,
+                    type: ProjectType.OpenData,
                     name: 'new name',
                     description: 'new description',
                 } as Project),
@@ -225,7 +225,7 @@ describe('product utils', () => {
         it('validates creator name', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.OPEN_DATA,
+                    type: ProjectType.OpenData,
                     creator: 'Julius Cesar'
                 } as Project),
             ).toStrictEqual({
@@ -238,7 +238,7 @@ describe('product utils', () => {
         it('validates image', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.OPEN_DATA,
+                    type: ProjectType.OpenData,
                     imageUrl: 'http://...',
                 } as Project),
             ).toStrictEqual({
@@ -250,7 +250,7 @@ describe('product utils', () => {
             })
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.OPEN_DATA,
+                    type: ProjectType.OpenData,
                     newImageToUpload: new File(['loremipsum'], 'foobar'),
                 } as Project),
             ).toStrictEqual({
@@ -264,7 +264,7 @@ describe('product utils', () => {
         it('validates streams', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.OPEN_DATA,
+                    type: ProjectType.OpenData,
                     streams: ['1', '2'],
                 } as Project),
             ).toStrictEqual({
@@ -278,7 +278,7 @@ describe('product utils', () => {
         it('validates data union required fields', () => {
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.DATA_UNION,
+                    type: ProjectType.DataUnion,
                     adminFee: '0.3',
                     dataUnionChainId: 123
                 } as Project),
@@ -294,7 +294,7 @@ describe('product utils', () => {
             })
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.DATA_UNION,
+                    type: ProjectType.DataUnion,
                     adminFee: '0',
                     dataUnionChainId: 123
                 } as Project),
@@ -310,7 +310,7 @@ describe('product utils', () => {
             })
             expect(
                 all.validate({
-                    type: ProjectTypeEnum.DATA_UNION,
+                    type: ProjectType.DataUnion,
                     adminFee: '1.1',
                     dataUnionChainId: null
                 } as Project),
@@ -347,7 +347,7 @@ describe('product utils', () => {
                 {
                     description: 'invalid pricePerSecond',
                     project: {
-                        type: ProjectTypeEnum.PAID_DATA,
+                        type: ProjectType.PaidData,
                         salePoints: {
                             [defaultSalePointChainName] : {
                                 ...defaultSalePoint,
@@ -360,7 +360,7 @@ describe('product utils', () => {
                 {
                     description: 'invalid beneficiaryAddress',
                     project: {
-                        type: ProjectTypeEnum.PAID_DATA,
+                        type: ProjectType.PaidData,
                         salePoints: {
                             [defaultSalePointChainName] : {
                                 ...defaultSalePoint,

--- a/app/test/unit/utils/product.test.ts
+++ b/app/test/unit/utils/product.test.ts
@@ -36,11 +36,7 @@ describe('product utils', () => {
         })
         it('detects data union product from value', () => {
             expect(all.isDataUnionProduct(ProjectType.DataUnion)).toBe(true)
-            expect(all.isDataUnionProduct('NORMAL')).toBe(false)
-        })
-        it('detects data union product from empty value', () => {
-            expect(all.isDataUnionProduct('')).toBe(false)
-            expect(all.isDataUnionProduct()).toBe(false)
+            expect(all.isDataUnionProduct(ProjectType.PaidData)).toBe(false)
         })
     })
     describe('validateProductPriceCurrency', () => {

--- a/app/test/unit/utils/validate.test.ts
+++ b/app/test/unit/utils/validate.test.ts
@@ -2,7 +2,7 @@ import BN from "bignumber.js"
 import * as all from '$mp/utils/validate'
 import { validateSalePoint } from '$mp/utils/validate'
 import * as constants from '$mp/utils/constants'
-import { ProjectTypeEnum } from '$mp/utils/constants'
+import { ProjectType } from '$shared/types'
 import { SalePoint } from '$mp/types/project-types'
 
 describe('validate utils', () => {
@@ -40,7 +40,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid pricePerSecond',
                 project: {
-                    projectType: ProjectTypeEnum.PAID_DATA,
+                    projectType: ProjectType.PaidData,
                     salePoint: {
                         ...defaultSalePoint,
                         pricePerSecond: new BN('-10')
@@ -51,7 +51,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid beneficiaryAddress',
                 project: {
-                    projectType: ProjectTypeEnum.PAID_DATA,
+                    projectType: ProjectType.PaidData,
                     salePoint: {
                         ...defaultSalePoint,
                         beneficiaryAddress: 'loremIpsum'
@@ -62,7 +62,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid existance of beneficiaryAddress for a DU Sale Point',
                 project: {
-                    projectType: ProjectTypeEnum.DATA_UNION,
+                    projectType: ProjectType.DataUnion,
                     salePoint: {
                         ...defaultSalePoint,
                         beneficiaryAddress: '0x7Ce38183F7851EE6eEB9547B1E537fB362C79C10'
@@ -73,7 +73,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid pricingTokenAddress',
                 project: {
-                    projectType: ProjectTypeEnum.PAID_DATA,
+                    projectType: ProjectType.PaidData,
                     salePoint: {
                         ...defaultSalePoint,
                         pricingTokenAddress: '0xa3934kd'
@@ -84,7 +84,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid chain',
                 project: {
-                    projectType: ProjectTypeEnum.PAID_DATA,
+                    projectType: ProjectType.PaidData,
                     salePoint: {
                         ...defaultSalePoint,
                         chainId: undefined
@@ -95,7 +95,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid price',
                 project: {
-                    projectType: ProjectTypeEnum.PAID_DATA,
+                    projectType: ProjectType.PaidData,
                     salePoint: {
                         ...defaultSalePoint,
                         price: new BN('0')
@@ -106,7 +106,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid timeUnit',
                 project: {
-                    projectType: ProjectTypeEnum.PAID_DATA,
+                    projectType: ProjectType.PaidData,
                     salePoint: {
                         ...defaultSalePoint,
                         timeUnit: '5',
@@ -117,7 +117,7 @@ describe('validate utils', () => {
             {
                 description: 'invalid timeUnit AND pricingTokenAddress for a DU',
                 project: {
-                    projectType: ProjectTypeEnum.DATA_UNION,
+                    projectType: ProjectType.DataUnion,
                     salePoint: {
                         ...defaultSalePoint,
                         timeUnit: '5',
@@ -130,7 +130,7 @@ describe('validate utils', () => {
         ].forEach((testCase) => {
             it(`should properly validate the SalePoint's ${testCase.description}`, () => {
                 expect(
-                    all.validateSalePoint(testCase.project.salePoint, testCase.project.projectType === ProjectTypeEnum.DATA_UNION)
+                    all.validateSalePoint(testCase.project.salePoint, testCase.project.projectType === ProjectType.DataUnion)
                 ).toEqual(testCase.expectedInvalidFields)
             })
         })


### PR DESCRIPTION
I'm trying to progressively make the project pages robust. This here is a prep for more fancy mods.

Key takeaways

- There's a `getters/index.ts` where I will place further `get*` functions. One place. Hopefully it works out. Larger ones can still be in separate files.
- `ProjectTypeEnum` is now `ProjectType`.
- There's just one `ProjectLinkTabs` for situations with and without project id.
- `Terms` and `Streams` got simplified and done more flexibly. I'll use them more later.