### PR TITLE
FRONT-1361: Smooth project page tabs

### DIFF
--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -21,10 +21,8 @@ import Analytics from '$shared/utils/Analytics'
 import GlobalInfoWatcher from '$mp/containers/GlobalInfoWatcher'
 import NewStreamListingPage from '$app/src/pages/NewStreamListingPage'
 import StreamEditPage from '$app/src/pages/StreamEditPage'
-import ProjectPage from '$mp/containers/ProjectPage'
+import ProjectPage from '$app/src/pages/ProjectPage'
 import ProjectsPage from '$mp/containers/Projects'
-import ProjectConnectPage from '$mp/containers/ProjectPage/ProjectConnectPage'
-import ProjectLiveDataPage from '$mp/containers/ProjectPage/ProjectLiveDataPage'
 import NewProjectPage from '$mp/containers/ProjectEditing/NewProjectPage'
 import EditProjectPage from '$mp/containers/ProjectEditing/EditProjectPage'
 import { AuthenticationControllerContextProvider } from '$auth/authenticationController'
@@ -66,19 +64,11 @@ const NewProjectPageAuth = (props) => {
     </UserIsAuthenticatedRoute>
 }
 
-const ProjectRedirect: FunctionComponent = () => {
-    const { id } = useParams<{id: string}>()
-    return <Redirect to={routes.projects.overview({id})}/>
-}
-
 const ProjectsRouter = (): ReactNode => [
     <Route exact path={routes.projects.index()} component={ProjectsPage} key="Projects" />,
     <Route exact path={routes.projects.new()} component={NewProjectPageAuth} key="NewProjectPage" />,
-    <Route exact path={routes.projects.show()} component={ProjectRedirect} key="ProjectRedirect"/>,
     <Route exact path={routes.projects.edit()} component={EditProjectPage} key="EditProjectPage" />,
-    <Route exact path={routes.projects.overview()} component={ProjectPage} key="ProjectDetailsOverviewPage" />,
-    <Route exact path={routes.projects.connect()} component={ProjectConnectPage} key="ProjectDetailsConnectPage" />,
-    <Route exact path={routes.projects.liveData()} component={ProjectLiveDataPage} key="ProjectDetailsLiveDataPage" />,
+    <Route path={routes.projects.show()} component={ProjectPage} key="Tabbed" />,
 ]
 
 const StreamsRouter = () => [

--- a/app/src/getters/index.ts
+++ b/app/src/getters/index.ts
@@ -68,3 +68,25 @@ export async function getAllowance(
         }
     }
 }
+
+export function getProjectImageUrl({
+    imageUrl,
+    imageIpfsCid,
+}: {
+    imageUrl?: string
+    imageIpfsCid?: string
+}) {
+    const {
+        ipfs: { ipfsGatewayUrl },
+    } = getCoreConfig()
+
+    if (imageIpfsCid) {
+        return `${ipfsGatewayUrl}${imageIpfsCid}`
+    }
+
+    if (!imageUrl) {
+        return
+    }
+
+    return `${imageUrl.replace(/^https:\/\/ipfs\.io\/ipfs\//, ipfsGatewayUrl)}`
+}

--- a/app/src/getters/index.ts
+++ b/app/src/getters/index.ts
@@ -2,6 +2,7 @@ import Web3 from 'web3'
 import { AbiItem } from 'web3-utils'
 import BigNumber from 'bignumber.js'
 import { toaster } from 'toasterhea'
+import { z } from 'zod'
 import { getConfigForChain } from '$shared/web3/config'
 import projectRegistryAbi from '$shared/web3/abis/projectRegistry.json'
 import { call } from '$mp/utils/smartContract'
@@ -9,6 +10,8 @@ import { erc20TokenContractMethods } from '$mp/utils/web3'
 import { marketplaceContract } from '$app/src/services/marketplace'
 import Toast, { ToastType } from '$shared/toasts/Toast'
 import { Layer } from '$utils/Layer'
+import getPublicWeb3 from '$utils/web3/getPublicWeb3'
+import { ProjectType } from '$shared/types'
 import getCoreConfig from './getCoreConfig'
 
 export function getGraphUrl() {
@@ -66,6 +69,49 @@ export async function getAllowance(
                 throw e
             }
         }
+    }
+}
+
+export async function getProjectPermissions(
+    chainId: number,
+    projectId: string,
+    account: string,
+) {
+    const response = await getProjectRegistryContract(chainId, getPublicWeb3(chainId))
+        .methods.getPermission(projectId, account)
+        .call()
+
+    const [canBuy = false, canDelete = false, canEdit = false, canGrant = false] = z
+        .array(z.boolean())
+        .parse(response)
+
+    return {
+        canBuy,
+        canDelete,
+        canEdit,
+        canGrant,
+    }
+}
+
+export function getProjectTypeName(projectType: ProjectType) {
+    switch (projectType) {
+        case ProjectType.DataUnion:
+            return 'Data Union'
+        case ProjectType.OpenData:
+            return 'open data project'
+        case ProjectType.PaidData:
+            return 'paid data project'
+    }
+}
+
+export function getProjectTypeTitle(projectType: ProjectType) {
+    switch (projectType) {
+        case ProjectType.DataUnion:
+            return 'Data Union'
+        case ProjectType.OpenData:
+            return 'Open Data'
+        case ProjectType.PaidData:
+            return 'Paid Data'
     }
 }
 

--- a/app/src/marketplace/components/PaymentRate/index.tsx
+++ b/app/src/marketplace/components/PaymentRate/index.tsx
@@ -29,7 +29,7 @@ const PaymentRate = (props: Props) => {
                 if (isMounted() && info) {
                     setCurrency(currencies.PRODUCT_DEFINED)
                     setSymbol(info.symbol)
-                    setDecimals(info.decimals)
+                    setDecimals(new BN(info.decimals))
                 }
             }
         }

--- a/app/src/marketplace/containers/ProjectPage/Hero/ProjectHero2.tsx
+++ b/app/src/marketplace/containers/ProjectPage/Hero/ProjectHero2.tsx
@@ -40,41 +40,48 @@ const customTheme = {
     text: COLORS.primaryLight
 }
 
-export const ProjectHero2: FunctionComponent<ProjectHeroProps> = ({project}) => {
+interface Props {
+    name: string
+    description: string
+    imageUrl: string | undefined
+    contact: Project['contact']
+}
+
+export default function ProjectHero2({ name, description, imageUrl, contact = {} }: Props) {
     return (
         <ProjectHeroContainer>
-            <ProjectHeroImage src={project.imageUrl} alt={project.name} noBorderRadius={true} />
-            <ProjectHeroTitle>{project.name}</ProjectHeroTitle>
-            <DescriptionEditor value={project.description} readOnly={true} theme={customTheme} />
+            <ProjectHeroImage src={imageUrl} alt={name} noBorderRadius={true} key={imageUrl || ''} />
+            <ProjectHeroTitle>{name}</ProjectHeroTitle>
+            <DescriptionEditor value={description} readOnly={true} theme={customTheme} />
             <ProjectHeroMetadataContainer>
-                {project.contact && (
+                {contact && (
                     <>
-                        {project.contact.url && (
-                            <DetailDisplay icon={<ProjectDetailIcon name={'web'} />} value={project.contact.url} link={project.contact.url} />
+                        {contact.url && (
+                            <DetailDisplay icon={<ProjectDetailIcon name={'web'} />} value={contact.url} link={contact.url} />
                         )}
-                        {project.contact.email && (
+                        {contact.email && (
                             <DetailDisplay
                                 icon={<ProjectDetailIcon name={'email'} />}
-                                value={project.contact.email}
-                                link={'mailto:' + project.contact.email}
+                                value={contact.email}
+                                link={'mailto:' + contact.email}
                             />
                         )}
-                        {project.contact.twitter && (
-                            <DetailDisplay icon={<ProjectDetailIcon name={'twitter'} className={'twitterColor'} />} link={project.contact.twitter} />
+                        {contact.twitter && (
+                            <DetailDisplay icon={<ProjectDetailIcon name={'twitter'} className={'twitterColor'} />} link={contact.twitter} />
                         )}
-                        {project.contact.telegram && (
+                        {contact.telegram && (
                             <DetailDisplay
                                 icon={<ProjectDetailIcon name={'telegram'} className={'telegramColor'} />}
-                                link={project.contact.telegram}
+                                link={contact.telegram}
                             />
                         )}
-                        {project.contact.reddit && (
-                            <DetailDisplay icon={<ProjectDetailIcon name={'reddit'} className={'redditColor'} />} link={project.contact.reddit} />
+                        {contact.reddit && (
+                            <DetailDisplay icon={<ProjectDetailIcon name={'reddit'} className={'redditColor'} />} link={contact.reddit} />
                         )}
-                        {project.contact.linkedIn && (
+                        {contact.linkedIn && (
                             <DetailDisplay
                                 icon={<ProjectDetailIcon name={'linkedin'} className={'linkedInColor'} />}
-                                link={project.contact.linkedIn}
+                                link={contact.linkedIn}
                             />
                         )}
                     </>

--- a/app/src/marketplace/containers/ProjectPage/utils.tsx
+++ b/app/src/marketplace/containers/ProjectPage/utils.tsx
@@ -1,32 +1,12 @@
 import React, { ReactNode } from 'react'
-import styled from "styled-components"
 import { Project } from '$mp/types/project-types'
-import { mapProjectTypeName } from "$mp/utils/project-mapper"
-
-const ProjectTitlePart = styled.strong`
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-`
-
-export const getProjectTitle = (project: Project): ReactNode => {
-    return (
-        <>
-            <ProjectTitlePart as={'span'}>{project.name}</ProjectTitlePart>
-            {!!project.creator && (
-                <>
-                    &nbsp;by&nbsp;<ProjectTitlePart>{project.creator}</ProjectTitlePart>
-                </>
-            )}
-        </>
-    )
-}
+import { getProjectTypeTitle } from '$app/src/getters'
 
 export const getProjectTitleForEditor = (project: Project): ReactNode => {
     return (
         !!project.creator && (
             <>
-                {mapProjectTypeName(project.type)} by
+                {getProjectTypeTitle(project.type)} by
                 <strong>&nbsp;{project.creator} </strong>
             </>
         )

--- a/app/src/marketplace/utils/project-mapper.ts
+++ b/app/src/marketplace/utils/project-mapper.ts
@@ -9,6 +9,9 @@ import {fromDecimals} from "$mp/utils/math"
 import {TimeUnit, timeUnitSecondsMultiplierMap} from "$shared/utils/timeUnit"
 import getCoreConfig from '$app/src/getters/getCoreConfig'
 
+/**
+ * @deprecated Use `getProjectImageUrl`.
+ */
 export const mapImageUrl = (graphProject: TheGraphProject) => {
     const { ipfs } = getCoreConfig()
     const { ipfsGatewayUrl } = ipfs
@@ -27,6 +30,9 @@ export const mapImageUrl = (graphProject: TheGraphProject) => {
     return imageUrl
 }
 
+/**
+ * @deprecated Use `projectEditor` to obtain both the graph projects and their local reflections.
+ */
 export const mapGraphProjectToDomainModel = async (graphProject: TheGraphProject): Promise<Project> => {
     return {
         id: graphProject.id,
@@ -43,6 +49,9 @@ export const mapGraphProjectToDomainModel = async (graphProject: TheGraphProject
     }
 }
 
+/**
+ * @deprecated Use `projectEditor` to obtain both the graph projects and their local reflections.
+ */
 export const mapProjectType = (graphProject: TheGraphProject): ProjectType => {
     // TODO when the TheGraphProject will have field which determines if it's a Data Union - implement a check here
     return graphProject.paymentDetails.length === 1 && graphProject.paymentDetails[0].pricePerSecond == '0'
@@ -50,6 +59,9 @@ export const mapProjectType = (graphProject: TheGraphProject): ProjectType => {
         : ProjectType.PaidData
 }
 
+/**
+ * @deprecated Use `projectEditor` to obtain both the graph projects and their local reflections.
+ */
 export const mapSalePoints = async (paymentDetails: TheGraphPaymentDetails[]): Promise<Record<ChainName, SalePoint>> => {
     const salePoints: Record<ChainName, SalePoint> = {}
     await Promise.all(paymentDetails.map(async (paymentDetail) => {
@@ -67,17 +79,4 @@ export const mapSalePoints = async (paymentDetails: TheGraphPaymentDetails[]): P
         }
     }))
     return salePoints
-}
-
-export const mapProjectTypeName = (projectType: ProjectType): string => {
-    switch (projectType) {
-        case ProjectType.OpenData:
-            return 'Open data'
-        case ProjectType.DataUnion:
-            return 'Data Union'
-        case ProjectType.PaidData:
-            return 'Paid data'
-        default:
-            return 'Project'
-    }
 }

--- a/app/src/pages/ProjectPage/AccessManifest.tsx
+++ b/app/src/pages/ProjectPage/AccessManifest.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+import BigNumber from 'bignumber.js'
+import { REGULAR, TABLET } from '$shared/utils/styled'
+import Button from '$shared/components/Button'
+import { ProjectType, SalePoint } from '$shared/types'
+import PaymentRate from '$mp/components/PaymentRate'
+import { formatChainName } from '$shared/utils/chains'
+import { WhiteBox } from '$shared/components/WhiteBox'
+import { getConfigForChain } from '$shared/web3/config'
+import { timeUnits } from '$shared/utils/timeUnit'
+import { getProjectTypeName } from '$app/src/getters'
+import { useIsProjectBeingPurchased, usePurchaseCallback } from '$shared/stores/purchases'
+import { errorToast } from '$utils/toast'
+import { useDoesUserHaveAccess } from '$shared/stores/projectEditor'
+import routes from '$routes'
+
+const DescriptionContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 18px;
+    font-weight: ${REGULAR};
+    flex-direction: column;
+
+    p {
+        margin: 0;
+    }
+
+    a {
+        width: 100%;
+        margin-top: 20px;
+    }
+
+    @media (${TABLET}) {
+        flex-direction: row;
+
+        a {
+            width: auto;
+            margin-top: 0;
+            margin-left: 20px;
+        }
+    }
+`
+
+interface Props {
+    projectId: string
+    projectType: ProjectType
+    salePoints: SalePoint[]
+}
+
+export default function AccessManifest({ projectId, projectType, salePoints }: Props) {
+    const [firstSalePoint, ...otherSalePoints] = salePoints
+
+    const prefix = `The streams in this ${getProjectTypeName(projectType)}`
+
+    const count = otherSalePoints.length
+
+    const purchase = usePurchaseCallback()
+
+    const hasAccess = useDoesUserHaveAccess()
+
+    const isBeingPurchased = useIsProjectBeingPurchased(projectId)
+
+    if (!firstSalePoint) {
+        return null
+    }
+
+    const { pricePerSecond, chainId, pricingTokenAddress } = firstSalePoint
+
+    return (
+        <WhiteBox>
+            <DescriptionContainer>
+                {projectType === ProjectType.OpenData ? (
+                    <p>
+                        {prefix} are public and can be accessed for <strong>free</strong>.
+                    </p>
+                ) : (
+                    <p>
+                        {prefix} can be accessed for{' '}
+                        <strong>
+                            {' '}
+                            <PaymentRate
+                                amount={new BigNumber(pricePerSecond)}
+                                chainId={chainId}
+                                pricingTokenAddress={pricingTokenAddress}
+                                timeUnit={timeUnits.hour}
+                                tag="span"
+                            />
+                        </strong>{' '}
+                        on{' '}
+                        <strong>
+                            {formatChainName(getConfigForChain(chainId).name)}
+                        </strong>
+                        {count > 0 && (
+                            <>
+                                and on {count} other chain{count > 1 && 's'}
+                            </>
+                        )}
+                        .
+                    </p>
+                )}
+                {hasAccess === true && (
+                    <Button tag={Link} to={routes.projects.connect({ id: projectId })}>
+                        Connect
+                    </Button>
+                )}
+                {hasAccess === false && (
+                    <Button
+                        type="button"
+                        waiting={isBeingPurchased}
+                        onClick={async () => {
+                            try {
+                                await purchase(projectId)
+                            } catch (e) {
+                                console.warn('Purchase failed', e)
+
+                                errorToast({
+                                    title: 'Purchase failed',
+                                })
+                            }
+                        }}
+                    >
+                        Get access
+                    </Button>
+                )}
+                {typeof hasAccess === 'undefined' && (
+                    <Button type="button" waiting>
+                        Loading…
+                    </Button>
+                )}
+            </DescriptionContainer>
+        </WhiteBox>
+    )
+}

--- a/app/src/pages/ProjectPage/GetAccess.tsx
+++ b/app/src/pages/ProjectPage/GetAccess.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import styled from 'styled-components'
+import BigNumber from 'bignumber.js'
+import PaymentRate from '$mp/components/PaymentRate'
+import { formatChainName } from '$shared/utils/chains'
+import Button from '$shared/components/Button'
+import ProjectPng from '$shared/assets/images/project.png'
+import { MEDIUM } from '$shared/utils/styled'
+import { getConfigForChain } from '$shared/web3/config'
+import { timeUnits } from '$shared/utils/timeUnit'
+import { ProjectType, SalePoint } from '$shared/types'
+import { getProjectTypeName } from '$app/src/getters'
+import {
+    useIsProjectBeingPurchased,
+    usePurchaseCallback
+} from '$app/src/shared/stores/purchases'
+import { errorToast } from '$utils/toast'
+
+const GetAccessContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 488px;
+    margin: 0 auto;
+    padding: 15px 0 100px;
+
+    img {
+        display: block;
+    }
+
+    h1 {
+        font-weight: ${MEDIUM};
+        font-size: 34px;
+        line-height: 44px;
+        margin-bottom: 19px;
+        text-align: center;
+    }
+
+    p {
+        font-size: 18px;
+        line-height: 30px;
+        margin-bottom: 50px;
+        text-align: center;
+    }
+`
+
+interface Props {
+    projectId: string
+    projectType: ProjectType
+    projectName: string
+    salePoints: SalePoint[]
+}
+
+export default function GetAccess({
+    projectId,
+    projectName,
+    projectType,
+    salePoints,
+}: Props) {
+    const [firstSalePoint, ...otherSalePoints] = salePoints
+
+    const count = otherSalePoints.length
+
+    const purchase = usePurchaseCallback()
+
+    const isBeingPurchased = useIsProjectBeingPurchased(projectId)
+
+    if (!firstSalePoint) {
+        return null
+    }
+
+    const { pricePerSecond, chainId, pricingTokenAddress } = firstSalePoint
+
+    return (
+        <>
+            <GetAccessContainer>
+                <img src={ProjectPng} alt="Get access" width="290" height="265" />
+                <h1>Get access to {projectName}</h1>
+                <p>
+                    The streams in this {getProjectTypeName(projectType)} can be accessed
+                    for
+                    <br />
+                    <strong>
+                        <PaymentRate
+                            amount={new BigNumber(pricePerSecond)}
+                            chainId={chainId}
+                            pricingTokenAddress={pricingTokenAddress}
+                            timeUnit={timeUnits.hour}
+                            tag="span"
+                        />
+                    </strong>{' '}
+                    on <strong>{formatChainName(getConfigForChain(chainId).name)}</strong>
+                    {count > 0 && (
+                        <>
+                            and on {count} other chain{count > 1 && 's'}
+                        </>
+                    )}
+                </p>
+                <Button
+                    type="button"
+                    waiting={isBeingPurchased}
+                    onClick={async () => {
+                        try {
+                            await purchase(projectId)
+                        } catch (e) {
+                            console.warn('Purchase failed', e)
+
+                            errorToast({
+                                title: 'Purchase failed',
+                            })
+                        }
+                    }}
+                >
+                    Get access
+                </Button>
+            </GetAccessContainer>
+        </>
+    )
+}

--- a/app/src/pages/ProjectPage/TabbedPage.tsx
+++ b/app/src/pages/ProjectPage/TabbedPage.tsx
@@ -1,0 +1,191 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link, useParams } from 'react-router-dom'
+import {
+    useDoesUserHaveAccess,
+    useIsProjectBusy,
+    useProject,
+} from '$shared/stores/projectEditor'
+import {
+    ProjectPermission,
+    useCurrentProjectAbility,
+} from '$shared/stores/projectAbilities'
+import Layout from '$shared/components/Layout'
+import { MarketplaceHelmet } from '$shared/components/Helmet'
+import { DetailsPageHeader } from '$shared/components/DetailsPageHeader'
+import LoadingIndicator from '$shared/components/LoadingIndicator'
+import Button from '$shared/components/Button'
+import SvgIcon from '$shared/components/SvgIcon'
+import PP, { ProjectPageContainer } from '$shared/components/ProjectPage'
+import { WhiteBox } from '$shared/components/WhiteBox'
+import { StreamConnect } from '$shared/components/StreamConnect'
+import { StreamPreview } from '$shared/components/StreamPreview'
+import Terms from '$mp/components/ProductPage/Terms'
+import Streams from '$mp/containers/ProjectPage/Streams'
+import ProjectHero from '$mp/containers/ProjectPage/Hero/ProjectHero2'
+import { SalePoint } from '$shared/types'
+import routes from '$routes'
+import ProjectLinkTabs from './ProjectLinkTabs'
+import AccessManifest from './AccessManifest'
+import GetAccess from './GetAccess'
+
+const PageTitleContainer = styled.div`
+    align-items: center;
+    display: flex;
+`
+
+const EditButton = styled(Button)`
+    border-radius: 100%;
+    height: 32px;
+    margin-left: 10px;
+    width: 32px;
+`
+
+const ProjectTitle = styled.span`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`
+
+const Separator = styled.span`
+    white-space: pre-wrap;
+`
+
+function ProjectOverviewPage() {
+    const {
+        id,
+        name,
+        description,
+        termsOfUse,
+        imageUrl,
+        streams,
+        type,
+        contact,
+        salePoints = {},
+    } = useProject()
+
+    if (!id) {
+        return null
+    }
+
+    return (
+        <PP>
+            <ProjectPageContainer>
+                <ProjectHero
+                    contact={contact}
+                    description={description}
+                    imageUrl={imageUrl || undefined}
+                    name={name}
+                />
+                <AccessManifest
+                    projectId={id}
+                    projectType={type}
+                    salePoints={Object.values(salePoints).filter(Boolean) as SalePoint[]}
+                />
+                <Streams streams={streams} />
+                <Terms terms={termsOfUse} />
+            </ProjectPageContainer>
+        </PP>
+    )
+}
+
+function ProjectConnectPage() {
+    const hasAccess = useDoesUserHaveAccess()
+
+    const { id, name, type, streams, salePoints = {} } = useProject()
+
+    if (!id) {
+        return null
+    }
+
+    return (
+        <PP>
+            <ProjectPageContainer>
+                {hasAccess ? (
+                    <WhiteBox>
+                        <StreamConnect streams={streams} />
+                    </WhiteBox>
+                ) : (
+                    <GetAccess
+                        projectId={id}
+                        projectName={name}
+                        projectType={type}
+                        salePoints={Object.values(salePoints) as SalePoint[]}
+                    />
+                )}
+            </ProjectPageContainer>
+        </PP>
+    )
+}
+
+function ProjectLiveDataPage() {
+    const hasAccess = useDoesUserHaveAccess()
+
+    const { id, name, type, streams, salePoints = {} } = useProject()
+
+    if (!id) {
+        return null
+    }
+
+    return hasAccess ? (
+        <StreamPreview streamsList={streams} />
+    ) : (
+        <PP>
+            <ProjectPageContainer>
+                <GetAccess
+                    projectId={id}
+                    projectName={name}
+                    projectType={type}
+                    salePoints={Object.values(salePoints) as SalePoint[]}
+                />
+            </ProjectPageContainer>
+        </PP>
+    )
+}
+
+export default function TabbedPage() {
+    const { tab } = useParams<{ tab: 'overview' | 'connect' | 'live-data' }>()
+
+    const { id, name, creator } = useProject()
+
+    const busy = useIsProjectBusy()
+
+    const canEdit = useCurrentProjectAbility(ProjectPermission.Edit)
+
+    return (
+        <Layout gray>
+            <MarketplaceHelmet title={name} />
+            <DetailsPageHeader
+                backButtonLink={routes.projects.index()}
+                pageTitle={
+                    <PageTitleContainer>
+                        <ProjectTitle>
+                            {name}
+                            {!!creator && (
+                                <>
+                                    <Separator> by </Separator>
+                                    <strong>{creator}</strong>
+                                </>
+                            )}
+                        </ProjectTitle>
+                        {canEdit && (
+                            <EditButton
+                                tag={Link}
+                                to={routes.projects.edit({ id })}
+                                kind="secondary"
+                                size="mini"
+                            >
+                                <SvgIcon name="pencilFull" />
+                            </EditButton>
+                        )}
+                    </PageTitleContainer>
+                }
+                rightComponent={<ProjectLinkTabs projectId={id} />}
+            />
+            <LoadingIndicator loading={busy} />
+            {tab === 'overview' && <ProjectOverviewPage />}
+            {tab === 'connect' && <ProjectConnectPage />}
+            {tab === 'live-data' && <ProjectLiveDataPage />}
+        </Layout>
+    )
+}

--- a/app/src/pages/ProjectPage/index.tsx
+++ b/app/src/pages/ProjectPage/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Redirect, Route, Switch, useParams } from 'react-router-dom'
+import { ProjectDraftContext, useInitProject } from '$shared/stores/projectEditor'
+import routes from '$routes'
+import TabbedPage from './TabbedPage'
+
+function NewProjectPage(): JSX.Element {
+    throw new Error('Not implemented.')
+}
+
+function EditProjectPage(): JSX.Element {
+    throw new Error('Not implemented.')
+}
+
+function ProjectRedirect() {
+    const { id } = useParams<{ id: string }>()
+
+    return <Redirect to={routes.projects.overview({ id })} />
+}
+
+export default function ProjectPage() {
+    const { id: projectId = 'new' } = useParams<{ id: string }>()
+
+    return (
+        <ProjectDraftContext.Provider
+            value={useInitProject(
+                projectId === 'new' ? undefined : decodeURIComponent(projectId),
+            )}
+        >
+            <Switch>
+                <Route
+                    exact
+                    path={routes.projects.new()}
+                    component={NewProjectPage}
+                    key="NewProjectPage"
+                />
+                <Route
+                    exact
+                    path={routes.projects.show()}
+                    component={ProjectRedirect}
+                    key="ProjectRedirect"
+                />
+                <Route
+                    exact
+                    path={routes.projects.edit()}
+                    component={EditProjectPage}
+                    key="EditProjectPage"
+                />
+                <Route
+                    exact
+                    path={routes.projects.showTab()}
+                    component={TabbedPage}
+                    key="TabbedPage"
+                />
+            </Switch>
+        </ProjectDraftContext.Provider>
+    )
+}

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -37,6 +37,7 @@
     "projects": {
         "index": "/hub/projects",
         "show": "/hub/projects/:id",
+        "showTab": "/hub/projects/:id/:tab(overview|connect|live-data)",
         "new": "/hub/projects/new",
         "edit": "/hub/projects/:id/edit",
         "overview": "/hub/projects/:id/overview",

--- a/app/src/services/projects.ts
+++ b/app/src/services/projects.ts
@@ -2,7 +2,6 @@ import BN from "bignumber.js"
 import getCoreConfig from "$app/src/getters/getCoreConfig"
 import { post } from "$shared/utils/api"
 import { send } from '$mp/utils/smartContract'
-import {ProjectId} from "$mp/types/project-types"
 import { Address, SmartContractCall, SmartContractTransaction } from "$shared/types/web3-types"
 import { getConfigForChainByName } from '$shared/web3/config'
 import address0 from "$utils/address0"
@@ -346,16 +345,6 @@ export const createProject = (project: SmartContractProjectCreate): SmartContrac
     return send(methodToSend, {
         network: chainId,
     })
-}
-
-export const getUserPermissionsForProject = async (
-    chainId: number,
-    projectId: ProjectId,
-    userAddress: Address,
-): SmartContractCall<ProjectPermissions> => {
-    const response = await getProjectRegistryContract(chainId, getPublicWeb3(chainId)).methods.getPermission(projectId, userAddress).call()
-    const { canDelete, canEdit, canGrant, canBuy } = response
-    return { canDelete, canEdit, canGrant, canBuy }
 }
 
 export const updateProject = (project: SmartContractProject): SmartContractTransaction => {

--- a/app/src/shared/components/Layout/index.tsx
+++ b/app/src/shared/components/Layout/index.tsx
@@ -1,3 +1,4 @@
+import styled, { css } from 'styled-components'
 import { ThemeProvider } from 'styled-components'
 import { NavProvider } from '@streamr/streamr-layout'
 import React, { FunctionComponent, ReactNode } from 'react'
@@ -7,13 +8,15 @@ import useCurrentLocation from '$shared/hooks/useCurrentLocation'
 import Nav from './Nav'
 import Footer from './Footer'
 import styles from './layout.pcss'
-type Props = {
-    theme?: any
-    footer?: boolean
-    nav?: any
-    framedClassname?: string
-    innerClassname?: string
-}
+
+const Inner = styled.div<{ $gray?: boolean }>`
+    background-color: white;
+
+    ${({ $gray = false }) => $gray && css`
+        background-color: #F5F5F5;
+    `}
+`
+
 const DefaultTheme = {}
 
 type LayoutProps = {
@@ -24,13 +27,16 @@ type LayoutProps = {
     innerClassName?: string,
     children?: ReactNode | ReactNode[],
     className?: string
+    gray?: boolean
 }
+
 const Layout: FunctionComponent<LayoutProps> = ({
     theme = DefaultTheme,
     footer = true,
     nav = <Nav />,
     framedClassName,
     innerClassName,
+    gray = false,
     ...props
 }: LayoutProps = {}) => {
     useScrollToTop()
@@ -39,10 +45,10 @@ const Layout: FunctionComponent<LayoutProps> = ({
         <ThemeProvider theme={theme}>
             <NavProvider highlight={current}>
                 <div className={cx(styles.framed, framedClassName)}>
-                    <div className={cx(styles.inner, innerClassName)}>
+                    <Inner className={cx(styles.inner, innerClassName)} $gray={gray}>
                         {nav}
                         <div {...props} />
-                    </div>
+                    </Inner>
                     {!!footer && <Footer />}
                 </div>
             </NavProvider>

--- a/app/src/shared/components/Layout/layout.pcss
+++ b/app/src/shared/components/Layout/layout.pcss
@@ -4,7 +4,6 @@
 }
 
 .framed .inner {
-  background-color: white;
   display: flex;
   flex-direction: column;
   font-size: 16px;

--- a/app/src/shared/components/Tile/index.tsx
+++ b/app/src/shared/components/Tile/index.tsx
@@ -9,7 +9,7 @@ import Link from '$shared/components/Link'
 import SvgIcon from '$shared/components/SvgIcon'
 import { COLORS } from '$shared/utils/styled'
 import { TheGraphProject } from '$app/src/services/projects'
-import { mapImageUrl } from '$mp/utils/project-mapper'
+import { getProjectImageUrl } from '$app/src/getters'
 import routes from '$routes'
 import Label, { HAPPY, ANGRY, WORRIED } from './Label'
 import Summary from './Summary'
@@ -43,7 +43,7 @@ type ThumbnailProps = {
 }
 
 const UnstyledThumbnail = ({ src, skeletonize, alt, ...props }: ThumbnailProps) =>
-    src != null &&
+    !!src &&
     (skeletonize ? (
         <Image {...props} as={Skeleton} block />
     ) : (
@@ -221,7 +221,7 @@ const ProductTile = ({ actions, deployed, published, numMembers, product, showDa
                 }
             >
                 <TileImageContainer autoSize>
-                    <TileThumbnail src={mapImageUrl(product) || ''} />
+                    <TileThumbnail src={getProjectImageUrl(product.metadata) || ''} />
                 </TileImageContainer>
             </Link>
             {!!showDataUnionBadge && <DataUnionBadge top left memberCount={numMembers} linkTo={routes.projects.index()} />}
@@ -255,7 +255,12 @@ const MarketplaceProductTile = ({ product, showDataUnionBadge, showEditButton, .
                 })}
             >
                 <TileImageContainer autoSize>
-                    <TileThumbnail src={mapImageUrl(product) || ''} />
+                    <TileThumbnail
+                        src={getProjectImageUrl({
+                            ...product.metadata,
+                            imageIpfsCid: product.metadata.imageIpfsCid || undefined,
+                        }) || ''}
+                    />
                 </TileImageContainer>
             </Link>
             {!!showDataUnionBadge && (

--- a/app/src/shared/stores/projectAbilities.ts
+++ b/app/src/shared/stores/projectAbilities.ts
@@ -1,0 +1,152 @@
+import { create } from 'zustand'
+import { useEffect } from 'react'
+import produce from 'immer'
+import { useAuthController } from '$auth/hooks/useAuthController'
+import { getProjectPermissions } from '$app/src/getters'
+import getCoreConfig from '$app/src/getters/getCoreConfig'
+import { useProject } from '$shared/stores/projectEditor'
+import address0 from "$utils/address0"
+
+export enum ProjectPermission {
+    Buy,
+    Delete,
+    Edit,
+    Grant,
+}
+
+interface Store {
+    fetchPermissions: (
+        chainId: number,
+        projectId: string,
+        account: string,
+    ) => Promise<void>
+    invalidate: (chainId: number, projectId: string, account: string) => void
+    permissions: Record<
+        string, // [chainId, projectId, account]
+        | {
+              cache?: number
+              value?: {
+                  canBuy: boolean
+                  canDelete: boolean
+                  canEdit: boolean
+                  canGrant: boolean
+              }
+          }
+        | undefined
+    >
+}
+
+function key(chainId: number, projectId: string, account: string) {
+    return JSON.stringify([chainId, projectId, account.toLowerCase()])
+}
+
+const useProjectAbilitiesStore = create<Store>((set, get) => {
+    const fetching: Record<string, boolean | undefined> = {}
+
+    return {
+        permissions: {},
+
+        async fetchPermissions(chainId, projectId, account) {
+            const pkey = key(chainId, projectId, account)
+
+            const { [pkey]: isFetching = false } = fetching
+
+            if (isFetching) {
+                return
+            }
+
+            try {
+                fetching[pkey] = true
+
+                const permissions = await getProjectPermissions(
+                    chainId,
+                    projectId,
+                    account,
+                )
+
+                set((current) =>
+                    produce(current, (next) => {
+                        const { cache } = next.permissions[pkey] || {}
+
+                        next.permissions[pkey] = {
+                            cache,
+                            value: permissions,
+                        }
+                    }),
+                )
+            } finally {
+                delete fetching[pkey]
+            }
+        },
+
+        invalidate(chainId: number, projectId: string, account: string) {
+            set((current) =>
+                produce(current, (next) => {
+                    const pkay = key(chainId, projectId, account)
+
+                    const { cache = 0 } = next.permissions[pkay] || {}
+
+                    next.permissions[pkay] = {
+                        cache: cache + 1,
+                    }
+                }),
+            )
+        },
+    }
+})
+
+export function useProjectAbility(
+    chainId: number,
+    projectId: string | undefined,
+    account: string | undefined,
+    permission: ProjectPermission,
+) {
+    const { fetchPermissions, permissions } = useProjectAbilitiesStore()
+
+    const address = account || address0
+
+    const { value, cache = 0 } = (projectId ? permissions[key(chainId, projectId, address)] : undefined) || {}
+
+    useEffect(() => {
+        async function fn() {
+            if (!projectId) {
+                return
+            }
+
+            try {
+                await fetchPermissions(chainId, projectId, address)
+            } catch (e) {
+                console.warn('Could not fetch permissions', chainId, projectId, address, e)
+            }
+        }
+
+        fn()
+    }, [fetchPermissions, chainId, projectId, address, cache])
+
+    switch (permission) {
+        case ProjectPermission.Buy:
+            return value?.canBuy
+        case ProjectPermission.Delete:
+            return value?.canDelete
+        case ProjectPermission.Edit:
+            return value?.canEdit
+        case ProjectPermission.Grant:
+            return value?.canGrant
+        default:
+            throw new Error('Invalid permission')
+    }
+}
+
+export function useCurrentProjectAbility(permission: ProjectPermission) {
+    const { chainId } = getCoreConfig().projectRegistry
+
+    const { id } = useProject()
+
+    const { address } = useAuthController().currentAuthSession
+
+    return useProjectAbility(chainId, id, address, permission)
+}
+
+export function useInvalidateProjectAbilities() {
+    return useProjectAbilitiesStore().invalidate
+}

--- a/app/src/shared/stores/projectEditor.tsx
+++ b/app/src/shared/stores/projectEditor.tsx
@@ -1,0 +1,516 @@
+import { create } from 'zustand'
+import produce from 'immer'
+import isEqual from 'lodash/isEqual'
+import { z } from 'zod'
+import uniqueId from 'lodash/uniqueId'
+import { createContext, useContext, useEffect, useMemo } from 'react'
+import { getGraphUrl, getProjectImageUrl } from '$app/src/getters'
+import { post } from '$shared/utils/api'
+import { TimeUnit, timeUnitSecondsMultiplierMap } from '$shared/utils/timeUnit'
+import getCoreConfig from '$app/src/getters/getCoreConfig'
+import { getConfigForChain } from '$shared/web3/config'
+import { getTokenInformation } from '$mp/utils/web3'
+import { fromDecimals } from '$mp/utils/math'
+import { getMostRelevantTimeUnit } from '$mp/utils/price'
+import { useAuthController } from '$app/src/auth/hooks/useAuthController'
+import { isProjectOwnedBy } from '$app/src/marketplace/utils/product'
+import { ProjectType, Project } from '$shared/types'
+import { GraphProject } from '$shared/consts'
+import { useHasActiveProjectSubscription } from './purchases'
+
+type GraphProject = z.infer<typeof GraphProject>
+
+interface ProjectDraft {
+    abandoned: boolean
+    errors: Record<string, string | undefined>
+    persisting: boolean
+    project: {
+        hot: Project
+        cold: Project
+        graph: GraphProject | undefined
+        changed: boolean
+        fetching: boolean
+    }
+}
+
+interface ProjectEditorStore {
+    idMap: Record<string, string>
+    drafts: Record<string, ProjectDraft | undefined>
+    init: (draftId: string, projectId: string | undefined) => void
+    persist: (draftId: string) => Promise<void>
+    setError: (draftId: string, key: string, message: string) => void
+    teardown: (draftId: string, options?: { onlyAbandoned?: boolean }) => void
+    abandon: (draftId: string) => void
+}
+
+const initialProject: Project = {
+    id: undefined,
+    name: '',
+    description: '',
+    imageUrl: undefined,
+    imageIpfsCid: undefined,
+    newImageToUpload: undefined,
+    streams: [],
+    type: ProjectType.OpenData,
+    termsOfUse: {
+        termsName: '',
+        termsUrl: '',
+    },
+    contact: {
+        url: '',
+        email: '',
+        twitter: '',
+        telegram: '',
+        reddit: '',
+        linkedIn: '',
+    },
+    creator: '',
+    salePoints: {},
+}
+
+const initialDraft: ProjectDraft = {
+    abandoned: false,
+    errors: {},
+    persisting: false,
+    project: {
+        hot: initialProject,
+        cold: initialProject,
+        graph: undefined,
+        changed: false,
+        fetching: false,
+    },
+}
+
+const GraphResponse = z.object({
+    data: z.object({
+        projects: z.array(
+            GraphProject.extend({
+                metadata: z.string(),
+            }),
+        ),
+    }),
+})
+
+/**
+ * Fetches a project from the Graph.
+ * @param projectId Project id.
+ * @returns A project stored in the Graph with parsed `metadata`.
+ */
+async function fetchGraphProject(projectId: string) {
+    const result = await post({
+        url: getGraphUrl(),
+        data: {
+            query: `
+                query {
+                    projects(
+                        where: { id: "${projectId.toLowerCase()}" }
+                    ) {
+                        id
+                        counter
+                        domainIds
+                        score
+                        metadata
+                        streams
+                        minimumSubscriptionSeconds
+                        createdAt
+                        updatedAt
+                        paymentDetails {
+                            domainId
+                            beneficiary
+                            pricingTokenAddress
+                            pricePerSecond
+                        }
+                        subscriptions {
+                            userAddress
+                            endTimestamp
+                        }
+                        permissions {
+                            userAddress
+                            canBuy
+                            canDelete
+                            canEdit
+                            canGrant
+                        }
+                        purchases {
+                            subscriber
+                            subscriptionSeconds
+                            price
+                            fee
+                            purchasedAt
+                        }
+                    }
+                }
+            `,
+        },
+    })
+
+    try {
+        const [project = undefined] = GraphResponse.parse(result).data.projects
+
+        if (!project) {
+            return null
+        }
+
+        const metadata = GraphProject.shape.metadata.parse(JSON.parse(project.metadata))
+
+        return {
+            ...project,
+            metadata,
+        } as GraphProject
+    } catch (e) {
+        console.warn(e)
+    }
+
+    return null
+}
+
+async function getSalePointsFromPaymentDetails(
+    paymentDetails: GraphProject['paymentDetails'],
+): Promise<Project['salePoints']> {
+    const result: Project['salePoints'] = {}
+
+    for (let i = 0; i < paymentDetails.length; i++) {
+        try {
+            const { domainId, pricingTokenAddress, pricePerSecond, beneficiary } =
+                paymentDetails[i]
+
+            const { id: chainId, name: chainName } = getConfigForChain(Number(domainId))
+
+            const { decimals } =
+                (await getTokenInformation(pricingTokenAddress, chainId)) || {}
+
+            if (!decimals) {
+                throw new Error('Invalid decimals')
+            }
+
+            const pricePerSecondFromDecimals = fromDecimals(pricePerSecond, decimals)
+
+            const timeUnit: TimeUnit = getMostRelevantTimeUnit(pricePerSecondFromDecimals)
+
+            const multiplier = timeUnitSecondsMultiplierMap.get(timeUnit)
+
+            if (!multiplier) {
+                throw new Error('Invalid multiplier')
+            }
+
+            result[chainName] = {
+                chainId,
+                pricingTokenAddress: pricingTokenAddress.toLowerCase(),
+                pricePerSecond,
+                beneficiaryAddress: beneficiary.toLowerCase(),
+                timeUnit,
+                price: pricePerSecondFromDecimals.multipliedBy(multiplier).toString(),
+            }
+        } catch (e) {
+            console.warn('Could not convert payment details to sale point', e)
+        }
+    }
+
+    return result
+}
+
+async function getProjectFromGraphProject({
+    id,
+    metadata,
+    streams,
+    paymentDetails,
+}: GraphProject): Promise<Project> {
+    const {
+        name,
+        description,
+        creator,
+        imageUrl,
+        imageIpfsCid,
+        termsOfUse = initialProject.termsOfUse,
+        contactDetails: contact = initialProject.contact,
+    } = metadata
+
+    const {
+        ipfs: { ipfsGatewayUrl },
+    } = getCoreConfig()
+
+    const [payment = { pricePerSecond: '0' }, secondPayment] = paymentDetails
+
+    const salePoints = await getSalePointsFromPaymentDetails(paymentDetails)
+
+    return {
+        id,
+        type:
+            payment.pricePerSecond === '0' && !secondPayment
+                ? ProjectType.OpenData
+                : ProjectType.PaidData,
+        name,
+        description,
+        creator,
+        imageUrl: getProjectImageUrl({ imageUrl, imageIpfsCid }),
+        imageIpfsCid,
+        newImageToUpload: undefined,
+        streams,
+        termsOfUse: {
+            ...termsOfUse,
+            termsName: termsOfUse.termsName || '',
+            termsUrl: termsOfUse.termsUrl || '',
+        },
+        contact: {
+            url: contact.url || '',
+            email: contact.email || '',
+            twitter: contact.twitter || '',
+            telegram: contact.telegram || '',
+            reddit: contact.reddit || '',
+            linkedIn: contact.linkedIn || '',
+        },
+        salePoints,
+    }
+}
+
+const useProjectEditorStore = create<ProjectEditorStore>((set, get) => {
+    function isPersisting(draftId: string) {
+        return get().drafts[draftId]?.persisting === true
+    }
+
+    function setDraft(
+        draftId: string,
+        update: (draft: ProjectDraft) => void,
+        { force = false }: { force?: boolean } = {},
+    ) {
+        set((draft) =>
+            produce(draft, (state) => {
+                if (!state.drafts[draftId] && !force) {
+                    return
+                }
+
+                state.drafts[draftId] = produce(
+                    state.drafts[draftId] || initialDraft,
+                    update,
+                )
+            }),
+        )
+    }
+
+    function setProject(draftId: string, update: (project: Project) => void) {
+        setDraft(draftId, (draft) => {
+            update(draft.project.hot)
+
+            draft.project.changed = !isEqual(draft.project.hot, draft.project.cold)
+        })
+    }
+
+    return {
+        idMap: {},
+
+        drafts: {},
+
+        init(draftId, projectId) {
+            const recycled = !!get().drafts[draftId]
+
+            setDraft(
+                draftId,
+                (draft) => {
+                    draft.project.hot.id = projectId
+
+                    draft.project.cold.id = draft.project.hot.id
+
+                    draft.abandoned = false
+                },
+                {
+                    force: true,
+                },
+            )
+
+            if (!projectId || recycled) {
+                return
+            }
+
+            async function fetch(id: string) {
+                try {
+                    setDraft(draftId, (draft) => {
+                        draft.project.fetching = true
+                    })
+
+                    const graphProject = await fetchGraphProject(id)
+
+                    if (!graphProject) {
+                        throw new Error('Not found or invalid')
+                    }
+
+                    const project = await getProjectFromGraphProject(graphProject)
+
+                    setDraft(draftId, (draft) => {
+                        draft.project.hot = project
+
+                        draft.project.cold = project
+
+                        draft.project.graph = graphProject
+
+                        draft.project.changed = false
+                    })
+                } catch (e) {
+                    console.warn('Failed to load a project', e)
+                } finally {
+                    setDraft(draftId, (draft) => {
+                        draft.project.fetching = false
+                    })
+                }
+            }
+
+            fetch(projectId)
+        },
+
+        async persist(draftId) {
+            if (isPersisting(draftId)) {
+                return
+            }
+
+            try {
+                setDraft(draftId, (draft) => {
+                    draft.persisting = true
+                })
+
+                set((store) =>
+                    produce(store, (copy) => {
+                        const { id } = copy.drafts[draftId]?.project.cold || {}
+
+                        if (id) {
+                            copy.idMap[id] = draftId
+                        }
+                    }),
+                )
+
+                // @TODO implement persisting
+            } finally {
+                setDraft(draftId, (draft) => {
+                    draft.persisting = false
+                })
+
+                get().teardown(draftId, { onlyAbandoned: true })
+            }
+        },
+
+        setError(draftId, key, message) {
+            setDraft(draftId, (state) => {
+                if (!message) {
+                    return void delete state.errors[key]
+                }
+
+                state.errors[key] = message
+            })
+        },
+
+        abandon(draftId) {
+            set((store) =>
+                produce(store, ({ drafts }) => {
+                    const draft = drafts[draftId]
+
+                    if (!draft) {
+                        return
+                    }
+
+                    draft.abandoned = true
+                }),
+            )
+
+            if (!isPersisting(draftId)) {
+                get().teardown(draftId)
+            }
+        },
+
+        teardown(draftId, { onlyAbandoned = false } = {}) {
+            set((store) =>
+                produce(store, ({ idMap, drafts }) => {
+                    const draft = drafts[draftId]
+
+                    if (!draft) {
+                        return
+                    }
+
+                    const { id } = draft.project.cold
+
+                    if (!onlyAbandoned || draft.abandoned) {
+                        if (id) {
+                            delete idMap[id]
+                        }
+
+                        delete drafts[draftId]
+                    }
+                }),
+            )
+        },
+    }
+})
+
+export const ProjectDraftContext = createContext<string | undefined>(undefined)
+
+export function useInitProject(projectId: string | undefined) {
+    const recycledDraftId = useProjectEditorStore(({ idMap }) =>
+        projectId ? idMap[projectId] : undefined,
+    )
+
+    const draftId = useMemo(() => {
+        return recycledDraftId || uniqueId('ProjectDraft-')
+        /**
+         * We give each new project id a new draft id (unless we recycle), thus we've gotta
+         * disable react-hooks/exhaustive-deps for the next line (`projectId` may seem redundant).
+         */
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [projectId, recycledDraftId])
+
+    const { init, abandon } = useProjectEditorStore(({ init, abandon }) => ({
+        init,
+        abandon,
+    }))
+
+    useEffect(() => {
+        init(draftId, projectId)
+
+        return () => void abandon(draftId)
+    }, [draftId, init, abandon, projectId])
+
+    return draftId
+}
+
+function useDraftId() {
+    return useContext(ProjectDraftContext)
+}
+
+function useDraft() {
+    const draftId = useDraftId()
+
+    return useProjectEditorStore(({ drafts }) => (draftId ? drafts[draftId] : undefined))
+}
+
+export function useProject({ hot = false } = {}) {
+    const draft = useDraft()
+
+    return (hot ? draft?.project.hot : draft?.project.cold) || initialProject
+}
+
+export function useIsProjectBusy() {
+    const draft = useDraft()
+
+    return !draft || draft.persisting || draft.project.fetching
+}
+
+export function useDoesUserHaveAccess() {
+    const {
+        project: { cold, graph },
+    } = useDraft() || initialDraft
+
+    const { currentAuthSession: { address = undefined } = {} } = useAuthController() || {}
+
+    const hasActiveProjectSubscription = useHasActiveProjectSubscription(cold.id, address)
+
+    if (!graph) {
+        return false
+    }
+
+    if (cold.type === ProjectType.OpenData) {
+        return true
+    }
+
+    if (!address) {
+        return false
+    }
+
+    return isProjectOwnedBy(graph, address) || hasActiveProjectSubscription
+}

--- a/app/src/shared/stores/purchases.ts
+++ b/app/src/shared/stores/purchases.ts
@@ -704,7 +704,7 @@ export function useHasActiveProjectSubscription(
 ) {
     const { subscriptions, fetchSubscriptions } = usePurchaseStore()
 
-    const { cache, entries = [] } = (projectId && subscriptions[projectId]) || {}
+    const { cache } = (projectId && subscriptions[projectId]) || {}
 
     useEffect(() => {
         if (projectId) {
@@ -714,6 +714,12 @@ export function useHasActiveProjectSubscription(
 
     if (!projectId || !account) {
         return false
+    }
+
+    const { entries } = subscriptions[projectId] || {}
+
+    if (!entries) {
+        return
     }
 
     const { endTimestamp = '0' } =

--- a/app/src/shared/types/index.ts
+++ b/app/src/shared/types/index.ts
@@ -1,5 +1,55 @@
+import { TimeUnit } from '$shared/utils/timeUnit'
+
 export enum ProjectType {
     OpenData = 'OPEN_DATA',
     PaidData = 'PAID_DATA',
     DataUnion = 'DATA_UNION'
 }
+
+export interface SalePoint {
+    chainId: number
+    beneficiaryAddress: string
+    pricePerSecond: string
+    timeUnit: TimeUnit
+    price: string
+    pricingTokenAddress: string
+}
+
+interface RegularProject {
+    id: string | undefined
+    name: string
+    description: string
+    imageUrl: string | undefined
+    imageIpfsCid: string | undefined
+    newImageToUpload: File | undefined
+    streams: string[]
+    type: ProjectType.OpenData | ProjectType.PaidData
+    termsOfUse: {
+        commercialUse?: boolean
+        redistribution?: boolean
+        reselling?: boolean
+        storage?: boolean
+        termsName: string
+        termsUrl: string
+    }
+    contact: {
+        url: string
+        email: string
+        twitter: string
+        telegram: string
+        reddit: string
+        linkedIn: string
+    }
+    creator: string | undefined
+    salePoints: Record<string, SalePoint | undefined>
+}
+
+interface DataUnionProject extends Omit<RegularProject, 'type'> {
+    type: ProjectType.DataUnion
+    adminFee: string | undefined
+    dataUnionDeployed: boolean
+    existingDUAddress: string | undefined
+    dataUnionChainId: number | undefined
+}
+
+export type Project = RegularProject | DataUnionProject


### PR DESCRIPTION
In this PR I make it possible to switch between Project overview, Connect, and the Live data pages without remounting pretty much the entire page.

It sure is more than just the tabs though. I prep for some project create/edit flow restructuring to make it more robust.

The pages I touch here use a different loading mechanism (less `Context`, more `zustand`).

Cheers!