### PR TITLE
[FRONT-1351] Fix project transactions

### DIFF
--- a/app/src/marketplace/containers/ProjectEditing/DeleteProject.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/DeleteProject.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import Button from '$shared/components/Button'
 import { useProjectState } from '$mp/contexts/ProjectStateContext'
 import { deleteProject } from '$app/src/services/projects'
@@ -22,6 +22,7 @@ const Description = styled.p`
 const DeleteProject = () => {
     const { state: project } = useProjectState()
     const history = useHistory()
+    const { pathname } = useLocation()
 
     return (
         <div>
@@ -32,7 +33,11 @@ const DeleteProject = () => {
                 onClick={async () => {
                     try {
                         await deleteProject(project?.id || undefined)
-                        history.push(routes.projects.index())
+
+                        // Navigate away from now gone project (if user stayed on the edit page)
+                        if (pathname === routes.projects.edit({ id: project?.id })) {
+                            history.push(routes.projects.index())
+                        }
                     } catch (e) {
                         console.warn('Could not delete project', e)
                     }

--- a/app/src/marketplace/containers/ProjectEditing/DeleteProject.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/DeleteProject.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
+import { useHistory } from 'react-router-dom'
 import Button from '$shared/components/Button'
 import { useProjectState } from '$mp/contexts/ProjectStateContext'
 import { deleteProject } from '$app/src/services/projects'
+import routes from '$routes'
 
 const Title = styled.p`
   font-size: 34px;
@@ -19,6 +21,7 @@ const Description = styled.p`
 
 const DeleteProject = () => {
     const { state: project } = useProjectState()
+    const history = useHistory()
 
     return (
         <div>
@@ -29,6 +32,7 @@ const DeleteProject = () => {
                 onClick={async () => {
                     try {
                         await deleteProject(project?.id || undefined)
+                        history.push(routes.projects.index())
                     } catch (e) {
                         console.warn('Could not delete project', e)
                     }

--- a/app/src/services/projects.ts
+++ b/app/src/services/projects.ts
@@ -368,86 +368,122 @@ async function toastedProjectOperation(label: string, fn?: () => Promise<void>) 
 }
 
 export async function createProject(project: SmartContractProjectCreate) {
-    await toastedProjectOperation('Create project', async () => {
-        const chainId = getProjectRegistryChainId()
+    await toastedProjectOperation('Create project', () => {
+        return new Promise(async (resolve, reject) => {
+            const chainId = getProjectRegistryChainId()
 
-        const {
-            id,
-            paymentDetails,
-            streams,
-            minimumSubscriptionInSeconds,
-            isPublicPurchasable,
-            metadata,
-        } = project
-
-        const from = await getDefaultWeb3Account()
-
-        await networkPreflight(chainId)
-
-        await getProjectRegistryContract(chainId, getWeb3())
-            .methods.createProject(
+            const {
                 id,
-                getDomainIds(paymentDetails),
-                getPaymentDetails(paymentDetails),
+                paymentDetails,
                 streams,
                 minimumSubscriptionInSeconds,
                 isPublicPurchasable,
                 metadata,
-            )
-            .send({
-                from,
-                maxPriorityFeePerGas: null,
-                maxFeePerGas: null,
-            })
+            } = project
+
+            const from = await getDefaultWeb3Account()
+
+            await networkPreflight(chainId)
+
+            const tx = getProjectRegistryContract(chainId, getWeb3())
+                .methods.createProject(
+                    id,
+                    getDomainIds(paymentDetails),
+                    getPaymentDetails(paymentDetails),
+                    streams,
+                    minimumSubscriptionInSeconds,
+                    isPublicPurchasable,
+                    metadata,
+                )
+                .send({
+                    from,
+                    maxPriorityFeePerGas: null,
+                    maxFeePerGas: null,
+                })
+
+            tx
+                .on('error', (error) => {
+                    reject(error)
+                })
+                .on('confirmation', () => {
+                    resolve()
+                })
+
+            return tx
+        })
     })
 }
 
 export async function updateProject(project: SmartContractProject) {
-    await toastedProjectOperation('Update project', async () => {
-        const chainId = getProjectRegistryChainId()
+    await toastedProjectOperation('Update project', () => {
+        return new Promise(async (resolve, reject) => {
+            const chainId = getProjectRegistryChainId()
 
-        const { id, paymentDetails, streams, minimumSubscriptionInSeconds, metadata } =
-            project
+            const { id, paymentDetails, streams, minimumSubscriptionInSeconds, metadata } =
+                project
 
-        const from = await getDefaultWeb3Account()
+            const from = await getDefaultWeb3Account()
 
-        await networkPreflight(chainId)
+            await networkPreflight(chainId)
 
-        await getProjectRegistryContract(chainId, getWeb3())
-            .methods.updateProject(
-                id,
-                getDomainIds(paymentDetails),
-                getPaymentDetails(paymentDetails),
-                streams,
-                minimumSubscriptionInSeconds,
-                metadata,
-            )
-            .send({
-                from,
-                maxPriorityFeePerGas: null,
-                maxFeePerGas: null,
-            })
+            const tx = getProjectRegistryContract(chainId, getWeb3())
+                .methods.updateProject(
+                    id,
+                    getDomainIds(paymentDetails),
+                    getPaymentDetails(paymentDetails),
+                    streams,
+                    minimumSubscriptionInSeconds,
+                    metadata,
+                )
+                .send({
+                    from,
+                    maxPriorityFeePerGas: null,
+                    maxFeePerGas: null,
+                })
+
+            tx
+                .on('error', (error) => {
+                    reject(error)
+                })
+                .on('confirmation', () => {
+                    resolve()
+                })
+
+            return tx
+        })
     })
 }
 
 export async function deleteProject(projectId: string | undefined) {
-    await toastedProjectOperation('Delete project', async () => {
-        if (!projectId) {
-            throw new Error('No project')
-        }
+    await toastedProjectOperation('Delete project', () => {
+        return new Promise(async (resolve, reject) => {
+            if (!projectId) {
+                throw new Error('No project')
+            }
 
-        const chainId = getProjectRegistryChainId()
+            const chainId = getProjectRegistryChainId()
 
-        const from = await getDefaultWeb3Account()
+            const from = await getDefaultWeb3Account()
 
-        await networkPreflight(chainId)
+            await networkPreflight(chainId)
 
-        await getProjectRegistryContract(chainId, getWeb3())
-            .methods.deleteProject(projectId)
-            .send({
-                from,
-                maxPriorityFeePerGas: null,
-                maxFeePerGas: null,
-            })
+            const tx = getProjectRegistryContract(chainId, getWeb3())
+                .methods.deleteProject(projectId)
+                .send({
+                    from,
+                    maxPriorityFeePerGas: null,
+                    maxFeePerGas: null,
+                })
+
+            tx
+                .on('error', (error) => {
+                    reject(error)
+                })
+                .on('confirmation', () => {
+                    resolve()
+                })
+
+            return tx
+        })
     })
 }

--- a/app/src/services/projects.ts
+++ b/app/src/services/projects.ts
@@ -368,24 +368,24 @@ async function toastedProjectOperation(label: string, fn?: () => Promise<void>) 
 }
 
 export async function createProject(project: SmartContractProjectCreate) {
-    await toastedProjectOperation('Create project', () => {
-        return new Promise(async (resolve, reject) => {
-            const chainId = getProjectRegistryChainId()
+    await toastedProjectOperation('Create project', async () => {
+        const chainId = getProjectRegistryChainId()
 
-            const {
-                id,
-                paymentDetails,
-                streams,
-                minimumSubscriptionInSeconds,
-                isPublicPurchasable,
-                metadata,
-            } = project
+        const {
+            id,
+            paymentDetails,
+            streams,
+            minimumSubscriptionInSeconds,
+            isPublicPurchasable,
+            metadata,
+        } = project
 
-            const from = await getDefaultWeb3Account()
+        const from = await getDefaultWeb3Account()
 
-            await networkPreflight(chainId)
+        await networkPreflight(chainId)
 
-            const tx = getProjectRegistryContract(chainId, getWeb3())
+        return new Promise((resolve, reject) => {
+            getProjectRegistryContract(chainId, getWeb3())
                 .methods.createProject(
                     id,
                     getDomainIds(paymentDetails),
@@ -400,33 +400,29 @@ export async function createProject(project: SmartContractProjectCreate) {
                     maxPriorityFeePerGas: null,
                     maxFeePerGas: null,
                 })
-
-            tx
                 .on('error', (error) => {
                     reject(error)
                 })
-                .on('confirmation', () => {
+                .once('confirmation', () => {
                     resolve()
                 })
-
-            return tx
         })
     })
 }
 
 export async function updateProject(project: SmartContractProject) {
-    await toastedProjectOperation('Update project', () => {
-        return new Promise(async (resolve, reject) => {
-            const chainId = getProjectRegistryChainId()
+    await toastedProjectOperation('Update project', async () => {
+        const chainId = getProjectRegistryChainId()
 
-            const { id, paymentDetails, streams, minimumSubscriptionInSeconds, metadata } =
-                project
+        const { id, paymentDetails, streams, minimumSubscriptionInSeconds, metadata } =
+            project
 
-            const from = await getDefaultWeb3Account()
+        const from = await getDefaultWeb3Account()
 
-            await networkPreflight(chainId)
+        await networkPreflight(chainId)
 
-            const tx = getProjectRegistryContract(chainId, getWeb3())
+        return new Promise((resolve, reject) => {
+            getProjectRegistryContract(chainId, getWeb3())
                 .methods.updateProject(
                     id,
                     getDomainIds(paymentDetails),
@@ -440,50 +436,42 @@ export async function updateProject(project: SmartContractProject) {
                     maxPriorityFeePerGas: null,
                     maxFeePerGas: null,
                 })
-
-            tx
                 .on('error', (error) => {
                     reject(error)
                 })
-                .on('confirmation', () => {
+                .once('confirmation', () => {
                     resolve()
                 })
-
-            return tx
         })
     })
 }
 
 export async function deleteProject(projectId: string | undefined) {
-    await toastedProjectOperation('Delete project', () => {
-        return new Promise(async (resolve, reject) => {
-            if (!projectId) {
-                throw new Error('No project')
-            }
+    await toastedProjectOperation('Delete project', async () => {
+        if (!projectId) {
+            throw new Error('No project')
+        }
 
-            const chainId = getProjectRegistryChainId()
+        const chainId = getProjectRegistryChainId()
 
-            const from = await getDefaultWeb3Account()
+        const from = await getDefaultWeb3Account()
 
-            await networkPreflight(chainId)
+        await networkPreflight(chainId)
 
-            const tx = getProjectRegistryContract(chainId, getWeb3())
+        return new Promise((resolve, reject) => {
+            getProjectRegistryContract(chainId, getWeb3())
                 .methods.deleteProject(projectId)
                 .send({
                     from,
                     maxPriorityFeePerGas: null,
                     maxFeePerGas: null,
                 })
-
-            tx
                 .on('error', (error) => {
                     reject(error)
                 })
-                .on('confirmation', () => {
+                .once('confirmation', () => {
                     resolve()
                 })
-
-            return tx
         })
     })
 }


### PR DESCRIPTION
Fix project CRUD transactions to not fail when transaction is mined slowly as it is expected if user chooses low gasPrice or network is otherwise congested. Now the toast will represent actual state of the transaction.

Before this change transactions could fail if they were not confirmed within 50 blocks.

PS. Also added missing redirect after project delete.