### PR TITLE
Add `CONFIG_ENV` for better DX against production streams and projects

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -343,7 +343,7 @@ module.exports = {
             $routes: path.resolve(__dirname, 'src/routes/'),
             $utils: path.resolve(__dirname, 'src/utils/'),
             $ui: path.resolve(__dirname, 'src/shared/components/Ui'),
-            $config: path.resolve(__dirname, `src/config/${process.env.NODE_ENV}.toml`),
+            $config: path.resolve(__dirname, `src/config/${process.env.CONFIG_ENV || process.env.NODE_ENV}.toml`),
             // When duplicate bundles point to different places.
             '@babel/runtime': path.resolve(__dirname, 'node_modules/@babel/runtime'),
             'bn.js': path.resolve(__dirname, 'node_modules/bn.js'),

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -80,7 +80,7 @@ module.exports = {
                 test: /\.m?js$/,
                 resolve: {
                     fullySpecified: false,
-                },            
+                },
             },
             {
                 test: /.jsx?$/,


### PR DESCRIPTION
You can now have `CONFIG_ENV` set to `production` locally and see all the products and streams known to the Polygon Netzwerk.

Leave the var blank everywhere else (staging, production, …).

@pmichalowski @tumppi I'll get that in but won't deploy. I think it makes life so much easier. Let's take it back if we decide to!

Cheers!