### PR TITLE
FRONT-1409: Better navigation blocker

### DIFF
--- a/app/src/marketplace/containers/ProjectEditing/EditProjectPage.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/EditProjectPage.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent, ReactNode, useContext, useEffect, useMemo} from "react"
+import React, {FunctionComponent, ReactNode, useCallback, useContext, useEffect, useMemo} from "react"
 import styled from "styled-components"
 import {isEqual} from "lodash"
 import {useHistory} from "react-router-dom"
@@ -30,13 +30,13 @@ const UnstyledEditProjectPage: FunctionComponent = () => {
     const {loadedProject} = useLoadedProject()
 
     usePreventNavigatingAway({
-        isDirty: () => {
+        isDirty: useCallback(() => {
             if (publishInProgress) {
                return false
             }
 
             return !isEqual(loadedProject, project) && isAnyTouched()
-        },
+        }, [publishInProgress, loadedProject, project, isAnyTouched]),
     })
 
     const nonEditableSalePointChains = useMemo<number[]>(

--- a/app/src/marketplace/containers/ProjectEditing/NewProjectPage.tsx
+++ b/app/src/marketplace/containers/ProjectEditing/NewProjectPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useEffect, useMemo } from 'react'
+import React, { ReactNode, useCallback, useContext, useEffect, useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import qs from 'query-string'
@@ -38,13 +38,13 @@ const UnstyledNewProjectPage = ({ className }: Props) => {
     const { isAnyTouched, resetTouched } = useContext(ValidationContext)
 
     usePreventNavigatingAway({
-        isDirty: () => {
+        isDirty: useCallback(() => {
             if (publishInProgress) {
                 return false
             }
 
             return isAnyTouched()
-        },
+        }, [publishInProgress, isAnyTouched]),
     })
 
     useEffect(() => {

--- a/app/src/shared/components/Globals.tsx
+++ b/app/src/shared/components/Globals.tsx
@@ -1,7 +1,10 @@
+import { useCallback } from 'react'
 import { useIsPersistingAnyStreamDraft } from '$shared/stores/streamEditor'
 import { useIsAnyPurchaseInProgress } from '$shared/stores/purchases'
 import { useRouteMemoryWipeEffect } from '$shared/stores/routeMemory'
-import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
+import usePreventNavigatingAway, {
+    useBlockHistoryEffect,
+} from '$shared/hooks/usePreventNavigatingAway'
 
 export default function Globals() {
     const isPersistingAnyStreamDraft = useIsPersistingAnyStreamDraft()
@@ -9,14 +12,19 @@ export default function Globals() {
     const isAnyPurchaseInProgress = useIsAnyPurchaseInProgress()
 
     usePreventNavigatingAway({
-        isDirty(destination) {
-            if (typeof destination !== 'undefined') {
-                return false
-            }
+        isDirty: useCallback(
+            (destination) => {
+                if (typeof destination !== 'undefined') {
+                    return false
+                }
 
-            return isPersistingAnyStreamDraft || isAnyPurchaseInProgress
-        },
+                return isPersistingAnyStreamDraft || isAnyPurchaseInProgress
+            },
+            [isPersistingAnyStreamDraft, isAnyPurchaseInProgress],
+        ),
     })
+
+    useBlockHistoryEffect()
 
     useRouteMemoryWipeEffect()
 

--- a/app/src/shared/hooks/usePreventNavigatingAway.ts
+++ b/app/src/shared/hooks/usePreventNavigatingAway.ts
@@ -6,7 +6,7 @@ import { create } from 'zustand'
 
 type Blocker = {
     message: string
-    isDirty?: (destination?: string) => boolean
+    isDirty: (destination?: string) => boolean
 }
 
 interface BlockerStore {
@@ -97,7 +97,7 @@ export function useBlockHistoryEffect() {
          */
         return history.block(({ pathname }) => {
             const blocker = Object.values(blockers).find((blocker) => {
-                return blocker?.isDirty?.(pathname)
+                return blocker?.isDirty(pathname)
             })
 
             if (blocker) {

--- a/app/src/shared/hooks/usePreventNavigatingAway.ts
+++ b/app/src/shared/hooks/usePreventNavigatingAway.ts
@@ -1,5 +1,42 @@
+import produce from 'immer'
+import uniqueId from 'lodash/uniqueId'
 import { useEffect, useCallback } from 'react'
 import { useHistory } from 'react-router-dom'
+import { create } from 'zustand'
+
+type Blocker = {
+    message: string
+    isDirty?: (destination?: string) => boolean
+}
+
+interface BlockerStore {
+    blockers: Record<string, Blocker | undefined>
+    register: (blocker: Blocker) => () => void
+}
+
+const useBlockerStore = create<BlockerStore>((set) => {
+    return {
+        blockers: {},
+
+        register(blocker) {
+            const id = uniqueId('blocker-')
+
+            set((current) =>
+                produce(current, (next) => {
+                    next.blockers[id] = blocker
+                }),
+            )
+
+            return () => {
+                set((current) =>
+                    produce(current, (next) => {
+                        delete next.blockers[id]
+                    }),
+                )
+            }
+        },
+    }
+})
 
 function useBeforeUnload(fn: (e: BeforeUnloadEvent) => void) {
     useEffect(() => {
@@ -18,21 +55,23 @@ export default function usePreventNavigatingAway({
     message?: string
     isDirty: (destination?: string) => boolean
 }) {
-    const history = useHistory()
+    const { register } = useBlockerStore()
 
-    useEffect(
-        () =>
-            history.block(({ pathname }) => {
-                if (isDirty(pathname)) {
-                    return message
-                }
-            }),
-        [history, isDirty, message],
-    )
+    useEffect(() => {
+        return register({
+            message,
+            isDirty,
+        })
+    }, [register, isDirty, message])
 
     useBeforeUnload(
         useCallback(
             (e) => {
+                /**
+                 * Limitations of `history.block` don't apply to the `beforeunload`
+                 * events. We can register as many as we want and the browser will
+                 * take care of the rest.
+                 */
                 if (isDirty()) {
                     e.returnValue = message
 
@@ -44,4 +83,26 @@ export default function usePreventNavigatingAway({
             [isDirty, message],
         ),
     )
+}
+
+export function useBlockHistoryEffect() {
+    const { blockers } = useBlockerStore()
+
+    const history = useHistory()
+
+    useEffect(() => {
+        /**
+         * On each change to `blockers` we reblock history using the new set
+         * of potential blockers.
+         */
+        return history.block(({ pathname }) => {
+            const blocker = Object.values(blockers).find((blocker) => {
+                return blocker?.isDirty?.(pathname)
+            })
+
+            if (blocker) {
+                return blocker.message
+            }
+        })
+    }, [history, blockers])
 }


### PR DESCRIPTION
**Reason?**

`history.block` can only be called once at a time. This makes the previous `usePreventNavigatingAway` limited to a single block per route. We have 2, in most cases (stream page and the one in `Globals`).

**So(u)lution**

I set up a blocker registry and make `history.block` go through it and use the first eligible blocker. If it doesn't find any, it idles.

It does require us to keep an eye out on how we use `usePreventNavigatingAway` hook. `isDirty` better not be different on each rerender (i.e. use `useCallback`, or `useRef`).