### PR TITLE
FRONT-1472, FRONT-1474, FRONT-1475, FRONT-1479: Modal dialogs for Sponsorships and Operators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx"
       - name: Run Jest Tests
         run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs npx jest --verbose --useStderr --forceExit --coverage=false --logHeapUsage --runInBand
         env:
@@ -112,7 +112,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx"
       - name: Run Cypress tests
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx smtp"
       - name: Run Jest Tests
         run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs npx jest --verbose --useStderr --forceExit --coverage=false --logHeapUsage --runInBand
         env:
@@ -112,7 +112,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx smtp"
       - name: Run Cypress tests
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql redis core-api cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql core-api cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
       - name: Run Jest Tests
         run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs npx jest --verbose --useStderr --forceExit --coverage=false --logHeapUsage --runInBand
         env:
@@ -112,7 +112,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql redis core-api cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql core-api cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
       - name: Run Cypress tests
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql core-api cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
       - name: Run Jest Tests
         run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs npx jest --verbose --useStderr --forceExit --coverage=false --logHeapUsage --runInBand
         env:
@@ -112,7 +112,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql core-api cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 bridge broker-node-storage-1 nginx smtp"
       - name: Run Cypress tests
         uses: cypress-io/github-action@v5
         with:

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -22,7 +22,9 @@ import NewProjectPage from '$mp/containers/ProjectEditing/NewProjectPage'
 import EditProjectPage from '$mp/containers/ProjectEditing/EditProjectPage'
 import Globals from '$shared/components/Globals'
 import { Layer } from '$utils/Layer'
+import { FeatureFlag, isFeatureEnabled } from '$shared/utils/isFeatureEnabled'
 import routes from '$routes'
+import OperatorsPage from '~/pages/OperatorsPage'
 import { HubRouter } from '~/consts'
 import '../analytics'
 
@@ -70,6 +72,14 @@ const App = () => (
                                 <Route index element={<NewStreamListingPage />} />
                                 <Route path=":id/*" element={<StreamPage />} />
                             </Route>
+                            {isFeatureEnabled(FeatureFlag.PhaseTwo) && (
+                                <Route
+                                    path="/hub/operators/*"
+                                    errorElement={<ErrorPage />}
+                                >
+                                    <Route index element={<OperatorsPage />} />
+                                </Route>
+                            )}
                             {MiscRouter()}
                         </Routes>
                         <Container id={Layer.Modal} />

--- a/app/src/modals/BaseModal.tsx
+++ b/app/src/modals/BaseModal.tsx
@@ -42,7 +42,7 @@ export const RejectionReason = {
 }
 
 export interface BaseModalProps {
-    children?: ReactNode
+    children?: ReactNode | ((close: (reason?: unknown) => void) => ReactNode)
     onReject?: (reason?: any) => void
     onBeforeAbort?: (reason?: any) => boolean | null | void
     darkBackdrop?: boolean
@@ -140,7 +140,11 @@ export default function BaseModal({
                     <Pad>
                         <Interactive>
                             <AnimatedWrap $dismissed={dismissed}>
-                                <Wigglable ref={wigglyRef}>{children}</Wigglable>
+                                <Wigglable ref={wigglyRef}>
+                                    {typeof children === 'function'
+                                        ? children(close)
+                                        : children}
+                                </Wigglable>
                             </AnimatedWrap>
                         </Interactive>
                     </Pad>

--- a/app/src/modals/FormModal.tsx
+++ b/app/src/modals/FormModal.tsx
@@ -1,16 +1,19 @@
-import React from 'react'
-import styled from 'styled-components'
-import { COLORS, SANS, TABLET } from '$shared/utils/styled'
+import React, { ReactNode } from 'react'
+import styled, { css } from 'styled-components'
+import { COLORS, MEDIUM, SANS, TABLET } from '$shared/utils/styled'
 import Buttons, { ButtonActions } from '$shared/components/Buttons'
 import SvgIcon from '$shared/components/SvgIcon'
+import Label from '$ui/Label'
 import BaseModal, { BaseModalProps, Footer, RejectionReason } from './BaseModal'
 
-export interface FormModalProps extends BaseModalProps {
+export interface FormModalProps extends Omit<BaseModalProps, 'children'> {
+    children?: ReactNode
     title?: string
     onSubmit?: () => void | Promise<void>
     submitLabel?: string
     cancelLabel?: string
     canSubmit?: boolean
+    submitting?: boolean
 }
 
 export default function FormModal({
@@ -21,6 +24,7 @@ export default function FormModal({
     submitLabel = 'Submit',
     cancelLabel,
     canSubmit = true,
+    submitting = false,
     ...props
 }: FormModalProps) {
     const actions: ButtonActions = {}
@@ -41,35 +45,37 @@ export default function FormModal({
         kind: 'primary',
         type: 'submit',
         disabled: !canSubmit,
+        spinner: submitting,
     }
 
     return (
         <BaseModal {...props} onReject={onReject}>
-            <form
-                onSubmit={async (e) => {
-                    e.preventDefault()
+            {(close) => (
+                <form
+                    onSubmit={async (e) => {
+                        e.preventDefault()
 
-                    await onSubmit?.()
-                }}
-            >
-                <Root>
-                    <Head>
-                        <Title>{title}</Title>
-                        <CloseButton
-                            type="button"
-                            onClick={() => {
-                                onReject?.(RejectionReason.CloseButton)
-                            }}
-                        >
-                            <SvgIcon name="crossMedium" />
-                        </CloseButton>
-                    </Head>
-                    <Content>{children}</Content>
-                    <Footer $borderless $spacious>
-                        <Buttons actions={actions} />
-                    </Footer>
-                </Root>
-            </form>
+                        await onSubmit?.()
+                    }}
+                >
+                    <Root>
+                        <Head>
+                            <Title>{title}</Title>
+                            <CloseButton
+                                type="button"
+                                onClick={close}
+                                disabled={submitting}
+                            >
+                                <SvgIcon name="crossMedium" />
+                            </CloseButton>
+                        </Head>
+                        <Content>{children}</Content>
+                        <Footer $borderless $spacious>
+                            <Buttons actions={actions} />
+                        </Footer>
+                    </Root>
+                </form>
+            )}
         </BaseModal>
     )
 }
@@ -124,5 +130,136 @@ const CloseButton = styled.button`
     & > svg {
         width: 14px;
         height: 14px;
+    }
+`
+
+export const SectionHeadline = styled.h4`
+    font-size: 14px;
+    font-weight: normal;
+    line-height: 24px;
+    margin: 0 0 8px;
+`
+
+export const Hint = styled.div`
+    color: #525252;
+    font-size: 12px;
+    margin-top: 8px;
+    line-height: 20px;
+
+    p {
+        margin: 0;
+        width: 90%;
+    }
+
+    p + p {
+        margin-top: 0.25em;
+    }
+`
+
+export const Section = styled.div`
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.02);
+    background: #f1f1f1;
+    border-radius: 8px;
+    padding: 16px;
+
+    ${Label} {
+        line-height: 20px;
+    }
+
+    ul {
+        background: #f8f8f8;
+        font-size: 14px;
+        list-style: none;
+        margin: 16px 0 0;
+        padding: 16px;
+        border-radius: 8px;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02);
+    }
+
+    li {
+        display: flex;
+        align-items: center;
+    }
+
+    li + li {
+        margin-top: 16px;
+    }
+`
+
+export const Prop = styled.em<{ $invalid?: boolean }>`
+    opacity: 0.7;
+    color: #525252;
+    flex-grow: 1;
+    display: block;
+    font-style: normal;
+    font-size: 12px;
+    font-weight: ${MEDIUM};
+
+    ${({ $invalid = false }) =>
+        $invalid &&
+        css`
+            color: #d90c25;
+        `}
+`
+
+export const Appendix = styled.div`
+    height: 100%;
+    flex-shrink: 0;
+`
+
+export const TextAppendix = styled(Appendix)`
+    align-items: center;
+    display: flex;
+    padding: 0 18px;
+`
+
+export const FieldWrap = styled.div<{ $invalid?: boolean }>`
+    display: flex;
+    border: 1px solid transparent;
+    align-items: center;
+    background: #ffffff;
+    font-size: 14px;
+    border-radius: 8px;
+    height: 40px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+
+    :focus-within {
+        box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
+    }
+
+    ${Appendix} {
+        border-left: 1px solid #efefef;
+    }
+
+    ${({ $invalid = false }) =>
+        $invalid &&
+        css`
+            border: 1px solid #d90c25;
+
+            ${Appendix} {
+                border-color: #d90c25;
+            }
+        `}
+`
+
+export const TextInput = styled.input`
+    background: none;
+    border: 0;
+    backface-visibility: hidden;
+    font-size: inherit;
+    height: 100%;
+    color: #323232;
+    padding: 0 18px;
+    flex-grow: 1;
+    outline: 0;
+
+    ::-webkit-outer-spin-button,
+    ::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    &[type='number'] {
+        -moz-appearance: textfield;
     }
 `

--- a/app/src/modals/FormModal.tsx
+++ b/app/src/modals/FormModal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
-import { COLORS, MEDIUM, SANS, TABLET } from '$shared/utils/styled'
+import { COLORS, MEDIUM, REGULAR, SANS, TABLET } from '$shared/utils/styled'
 import Buttons, { ButtonActions } from '$shared/components/Buttons'
 import SvgIcon from '$shared/components/SvgIcon'
 import Label from '$ui/Label'
@@ -184,6 +184,10 @@ export const Section = styled.div`
     li + li {
         margin-top: 16px;
     }
+
+    & + & {
+        margin-top: 16px;
+    }
 `
 
 export const Prop = styled.em<{ $invalid?: boolean }>`
@@ -227,6 +231,10 @@ export const FieldWrap = styled.div<{ $invalid?: boolean }>`
         box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
     }
 
+    & + ${Label} {
+        margin-top: 24px;
+    }
+
     ${Appendix} {
         border-left: 1px solid #efefef;
     }
@@ -261,5 +269,24 @@ export const TextInput = styled.input`
 
     &[type='number'] {
         -moz-appearance: textfield;
+    }
+
+    &::placeholder {
+        color: #a3a3a3;
+    }
+`
+
+export const GroupHeadline = styled.h2`
+    font-size: 18px;
+    line-height: 24px;
+    font-weight: ${REGULAR};
+    margin: 0 0 24px;
+    border-bottom: 1px solid #efefef;
+    padding: 0 0 16px;
+`
+
+export const Group = styled.div`
+    & + & {
+        margin-top: 40px;
     }
 `

--- a/app/src/modals/FormModal.tsx
+++ b/app/src/modals/FormModal.tsx
@@ -318,3 +318,21 @@ export const IconWrapAppendix = styled(Appendix)`
     color: #a3a3a3;
     padding-right: 10px;
 `
+
+export const WingedLabelWrap = styled.div`
+    display: flex;
+    align-items: center;
+
+    ${Label} {
+        flex-grow: 1;
+    }
+
+    ${Label} + ${Label} {
+        flex-grow: 0;
+    }
+`
+
+export const ErrorLabel = styled(Label)`
+    color: #d90c25;
+    opacity: 0.7;
+`

--- a/app/src/modals/FormModal.tsx
+++ b/app/src/modals/FormModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import { COLORS, MEDIUM, REGULAR, SANS, TABLET } from '$shared/utils/styled'
 import Buttons, { ButtonActions } from '$shared/components/Buttons'
@@ -207,17 +207,17 @@ export const Prop = styled.em<{ $invalid?: boolean }>`
 `
 
 export const Appendix = styled.div`
-    height: 100%;
+    align-items: center;
+    display: flex;
     flex-shrink: 0;
+    height: 100%;
 `
 
 export const TextAppendix = styled(Appendix)`
-    align-items: center;
-    display: flex;
     padding: 0 18px;
 `
 
-export const FieldWrap = styled.div<{ $invalid?: boolean }>`
+export const FieldWrap = styled.div<{ $invalid?: boolean; $grayedOut?: boolean }>`
     display: flex;
     border: 1px solid transparent;
     align-items: center;
@@ -235,7 +235,7 @@ export const FieldWrap = styled.div<{ $invalid?: boolean }>`
         margin-top: 24px;
     }
 
-    ${Appendix} {
+    ${TextAppendix} {
         border-left: 1px solid #efefef;
     }
 
@@ -244,9 +244,16 @@ export const FieldWrap = styled.div<{ $invalid?: boolean }>`
         css`
             border: 1px solid #d90c25;
 
-            ${Appendix} {
+            ${TextAppendix} {
                 border-color: #d90c25;
             }
+        `}
+
+    ${({ $grayedOut = false }) =>
+        $grayedOut &&
+        css`
+            border-color: #f8f8f8;
+            background: #f8f8f8;
         `}
 `
 
@@ -289,4 +296,25 @@ export const Group = styled.div`
     & + & {
         margin-top: 40px;
     }
+`
+
+export const CopyButtonWrapAppendix = styled(Appendix)`
+    padding: 0 16px 0 0;
+
+    button {
+        align-items: center;
+        appearance: none;
+        background: #ffffff;
+        border: 0;
+        color: #525252;
+        display: flex;
+        height: 24px;
+        justify-content: center;
+        width: 24px;
+    }
+`
+
+export const IconWrapAppendix = styled(Appendix)`
+    color: #a3a3a3;
+    padding-right: 10px;
 `

--- a/app/src/pages/AbstractStreamEditPage/InfoSection/StreamId.tsx
+++ b/app/src/pages/AbstractStreamEditPage/InfoSection/StreamId.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
-import { SM, MONO, MEDIUM } from '$shared/utils/styled'
+import { SM } from '$shared/utils/styled'
 import SvgIcon from '$shared/components/SvgIcon'
 import Button from '$shared/components/Button'
 import Spinner from '$shared/components/Spinner'
@@ -17,6 +17,7 @@ import {
     useSetCurrentDraftTransientStreamId,
 } from '$shared/stores/streamEditor'
 import { useWalletAccount } from '$shared/stores/wallet'
+import Help from '~/components/Help'
 import useStreamOwnerOptionGroups, {
     ADD_ENS_DOMAIN_VALUE,
     OptionGroup,
@@ -36,7 +37,7 @@ export function ReadonlyStreamId({ streamId }: { streamId: string }) {
                 </PathnameField>
             </Pathname>
             <div>
-                <Label />
+                <Label keepSpace />
                 <Button
                     kind="secondary"
                     onClick={() =>
@@ -187,15 +188,14 @@ export function EditableStreamId({ disabled = false }: EditableStreamIdProps) {
                 )}
             </Domain>
             <div>
-                <Label />
+                <Label keepSpace />
                 <Separator />
             </div>
             <Pathname>
-                <LabelWrap>
-                    <Label>Path name</Label>
-                    <Hint>
-                        <SvgIcon name="outlineQuestionMark" />
-                        <Tooltip>
+                <Label>
+                    <LabelInner>
+                        <span>Path name</span>
+                        <Help align="right">
                             <p>Stream paths can be single or multi-level.</p>
                             <p>Single</p>
                             <pre>streamr.eth/coffeemachine</pre>
@@ -205,9 +205,9 @@ export function EditableStreamId({ disabled = false }: EditableStreamIdProps) {
                                 For more information, see the{' '}
                                 <a href="https://docs.streamr.network/">docs</a>.
                             </p>
-                        </Tooltip>
-                    </Hint>
-                </LabelWrap>
+                        </Help>
+                    </LabelInner>
+                </Label>
                 <PathnameField>
                     <Text
                         disabled={disabled}
@@ -261,82 +261,6 @@ const Pathname = styled.div`
 
     ${Label} {
         flex-grow: 1;
-    }
-`
-const LabelWrap = styled.div`
-    display: flex;
-`
-const Hint = styled.div`
-    color: #cdcdcd;
-    position: relative;
-    transition: 200ms color;
-
-    :hover {
-        color: #323232;
-    }
-
-    svg {
-        display: block;
-        left: -2px;
-        position: relative;
-        top: -2px;
-        width: 16px;
-    }
-`
-const Tooltip = styled.div`
-    background: #323232;
-    border-radius: 4px;
-    color: #ffffff;
-    font-size: 0.75rem;
-    line-height: 1rem;
-    padding: 0.5rem 0.75rem;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    top: 20px;
-    transform: translateY(4px);
-    transition: 200ms;
-    transition-property: visibility, opacity, transform;
-    transition-delay: 200ms, 0s, 0s;
-    visibility: hidden;
-    width: 250px;
-    z-index: 1;
-
-    pre {
-        color: inherit;
-        font-family: ${MONO};
-        font-size: 0.9em;
-        font-weight: ${MEDIUM};
-        margin: 0;
-        padding: 0;
-    }
-
-    pre,
-    p {
-        margin: 0;
-    }
-
-    pre + p,
-    p + p {
-        margin-top: 0.75em;
-    }
-
-    a {
-        color: inherit !important;
-        text-decoration: none;
-    }
-
-    a:focus,
-    a:hover {
-        text-decoration: underline;
-    }
-
-    ${Hint}:hover & {
-        opacity: 1;
-        transform: translateY(0);
-        transition-delay: 0s;
-        transition-duration: 50ms;
-        visibility: visible;
     }
 `
 const PathnameField = styled.div`
@@ -397,5 +321,14 @@ const StreamId = styled.div`
 
     > * + * {
         margin-left: 16px;
+    }
+`
+
+const LabelInner = styled.div`
+    align-items: center;
+    display: flex;
+
+    span {
+        flex-grow: 1;
     }
 `

--- a/app/src/shared/components/Ui/Label.tsx
+++ b/app/src/shared/components/Ui/Label.tsx
@@ -3,14 +3,15 @@ import styled from 'styled-components'
 import * as Colors from '$ui/StateColors'
 import { MEDIUM } from '$shared/utils/styled'
 
-const UnstyledLabel: FunctionComponent<
-    { className?: string; children?: ReactNode | ReactNode[] } & Partial<
-        HTMLProps<HTMLLabelElement>
-    >
-> = ({ className, children, ...props }) => {
+interface Props extends HTMLProps<HTMLLabelElement> {
+    keepSpace?: boolean
+}
+
+function UnstyledLabel({ children, keepSpace = false, ...props }: Props) {
     return (
-        <label className={className} {...props}>
-            {children}&zwnj;
+        <label {...props}>
+            {children}
+            {keepSpace ? <>&zwnj;</> : null}
         </label>
     )
 }

--- a/app/src/shared/utils/chains.tsx
+++ b/app/src/shared/utils/chains.tsx
@@ -33,26 +33,3 @@ export const formatChainName = (apiChainName: string): string => {
             return apiChainName
     }
 }
-export const getChainIdFromApiString = (name: string): number => {
-    // TODO: Kind of ugly hack to map production values to development environment.
-    //       This is needed because core-api uses production values in prepopulated data.
-    if (process.env.NODE_ENV === 'development') {
-        if (name === 'ETHEREUM' || name === 'dev0') {
-            return 8995
-        }
-
-        return 8997
-    }
-
-    const found = Object.entries(chainNameToIdMapping).find(
-        (val) => val[0].toLowerCase() === name.toLowerCase(),
-    )
-
-    if (found) {
-        const chainId = found[1]
-        // $FlowFixMe: mixed is incompatible with number (╯°□°）╯︵ ┻━┻
-        return chainId
-    }
-
-    throw Error(`Unknown chain name ${name}`)
-}

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -1,0 +1,123 @@
+import React, { ComponentProps, ReactNode } from 'react'
+import styled, { css } from 'styled-components'
+import SvgIcon from '$shared/components/SvgIcon'
+import { MEDIUM, MONO } from '$app/src/shared/utils/styled'
+
+type Alignment = 'left' | 'center' | 'right'
+
+interface Props {
+    children?: ReactNode
+    align?: Alignment
+}
+
+export default function Help({ children, align = 'left' }: Props) {
+    return (
+        <Root>
+            <QuestionMarkIcon />
+            <Tooltip $align={align}>{children}</Tooltip>
+        </Root>
+    )
+}
+
+function getQuestionMarkIconAttrs(): ComponentProps<typeof SvgIcon> {
+    return { name: 'outlineQuestionMark' }
+}
+
+const QuestionMarkIcon = styled(SvgIcon).attrs(getQuestionMarkIconAttrs)`
+    display: block;
+    height: 16px;
+    width: 16px;
+    transform: translateY(-2px);
+`
+
+const Root = styled.div`
+    color: #cdcdcd;
+    position: relative;
+    transition: 200ms color;
+    white-space: normal;
+    margin-left: 8px;
+    height: 12px;
+
+    :hover {
+        color: #323232;
+    }
+
+    p {
+        line-height: 1.5em;
+    }
+`
+
+const Tooltip = styled.div<{ $align?: Alignment }>`
+    background: #323232;
+    border-radius: 4px;
+    color: #ffffff;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    padding: 0.5rem 0.75rem;
+    opacity: 0;
+    position: absolute;
+    top: 20px;
+    transform: translateY(4px);
+    transition: 200ms;
+    transition-property: visibility, opacity, transform;
+    transition-delay: 200ms, 0s, 0s;
+    visibility: hidden;
+    width: 250px;
+    z-index: 1;
+
+    pre {
+        color: inherit;
+        font-family: ${MONO};
+        font-size: 0.9em;
+        font-weight: ${MEDIUM};
+        margin: 0;
+        padding: 0;
+    }
+
+    pre,
+    p {
+        margin: 0;
+    }
+
+    pre + p,
+    p + p {
+        margin-top: 0.75em;
+    }
+
+    a {
+        color: inherit !important;
+        text-decoration: none;
+    }
+
+    a:focus,
+    a:hover {
+        text-decoration: underline;
+    }
+
+    ${Root}:hover & {
+        opacity: 1;
+        transform: translateY(0);
+        transition-delay: 0s;
+        transition-duration: 50ms;
+        visibility: visible;
+    }
+
+    ${({ $align = 'left' }) => {
+        switch ($align) {
+            case 'right':
+                return css`
+                    right: 0;
+                `
+            case 'center':
+                return css`
+                    left: 50%;
+                    transform: translateY(4px) translateX(-50%);
+
+                    ${Root}:hover & {
+                        transform: translateY(0) translateX(-50%);
+                    }
+                `
+            default:
+        }
+    }}
+`

--- a/src/modals/BecomeOperatorModal.tsx
+++ b/src/modals/BecomeOperatorModal.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 import { RejectionReason } from '$app/src/modals/BaseModal'
 import FormModal, {
     FieldWrap,
     FormModalProps,
-    Hint,
     Prop,
     Section,
     SectionHeadline,
@@ -12,6 +12,7 @@ import FormModal, {
     TextInput,
 } from '$app/src/modals/FormModal'
 import Label from '$ui/Label'
+import Help from '~/components/Help'
 
 interface Props extends Omit<FormModalProps, 'canSubmit'> {
     operatorId?: string
@@ -84,7 +85,19 @@ export default function BecomeOperatorModal({
                 Please choose the percentage for the Operator&apos;s cut
             </SectionHeadline>
             <Section>
-                <Label>Operator&apos;s cut percentage</Label>
+                <Label>
+                    <LabelInner>
+                        <span>Operator&apos;s cut percentage</span>
+                        <Help align="center">
+                            <p>
+                                The cut taken by the Operator from all earnings. This
+                                percentage can not be changed later. The rest is shared
+                                among Delegators including the Operator&apos;s
+                                own&nbsp;stake.
+                            </p>
+                        </Help>
+                    </LabelInner>
+                </Label>
                 <FieldWrap>
                     <TextInput
                         name="cut"
@@ -99,13 +112,6 @@ export default function BecomeOperatorModal({
                     />
                     <TextAppendix>%</TextAppendix>
                 </FieldWrap>
-                <Hint>
-                    <p>
-                        The cut taken by the Operator from all earnings. This percentage
-                        can not be changed later. The rest is shared among Delegators
-                        including the Operator&apos;s own stake.
-                    </p>
-                </Hint>
                 <ul>
                     <li>
                         <Prop>Your wallet balance</Prop>
@@ -122,3 +128,8 @@ export default function BecomeOperatorModal({
         </FormModal>
     )
 }
+
+const LabelInner = styled.div`
+    align-items: center;
+    display: flex;
+`

--- a/src/modals/BecomeOperatorModal.tsx
+++ b/src/modals/BecomeOperatorModal.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react'
+import { RejectionReason } from '$app/src/modals/BaseModal'
+import FormModal, {
+    FieldWrap,
+    FormModalProps,
+    Hint,
+    Prop,
+    Section,
+    SectionHeadline,
+    TextAppendix,
+    TextInput,
+} from '$app/src/modals/FormModal'
+import Label from '$ui/Label'
+
+interface Props extends Omit<FormModalProps, 'canSubmit'> {
+    operatorId?: string
+    onResolve?: (cut: number) => void
+    cut?: number
+}
+
+export default function BecomeOperatorModal({
+    title = 'Become an Operator',
+    submitLabel = 'Become an Operator',
+    onResolve,
+    operatorId = 'N/A',
+    cut: cutProp,
+    ...props
+}: Props) {
+    const [busy, setBusy] = useState(false)
+
+    const cut = `${cutProp || ''}`
+
+    const [rawValue, setRawValue] = useState(cut)
+
+    useEffect(() => {
+        setRawValue(cut)
+    }, [cut])
+
+    const value = rawValue || '0'
+
+    const numericValue = Number.parseFloat(value)
+
+    const canSubmit =
+        `${numericValue}` === value && numericValue >= 0 && numericValue <= 100
+
+    return (
+        <FormModal
+            {...props}
+            title={title}
+            canSubmit={canSubmit && !busy}
+            submitLabel={submitLabel}
+            submitting={busy}
+            onBeforeAbort={(reason) =>
+                !busy && (rawValue === cut || reason !== RejectionReason.Backdrop)
+            }
+            onSubmit={async () => {
+                setBusy(true)
+
+                try {
+                    /**
+                     * Replace the following with your favourite contract interaction! <3
+                     */
+                    await new Promise((resolve) => void setTimeout(resolve, 2000))
+
+                    onResolve?.(numericValue)
+                } catch (e) {
+                    console.warn('Error while becoming an operator', e)
+                    setBusy(false)
+                } finally {
+                    /**
+                     * No need to reset `busy`. `onResolve` makes the whole modal disappear.
+                     */
+                }
+            }}
+        >
+            <SectionHeadline>Please choose your Operator&apos;s cut</SectionHeadline>
+            <Section>
+                <Label>Operator&apos;s cut</Label>
+                <FieldWrap>
+                    <TextInput
+                        name="cut"
+                        autoFocus
+                        onChange={({ target }) => void setRawValue(target.value)}
+                        placeholder="0"
+                        readOnly={busy}
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={rawValue}
+                    />
+                    <TextAppendix>%</TextAppendix>
+                </FieldWrap>
+                <Hint>
+                    <p>
+                        The cut taken by the Operator from all earnings. This percentage
+                        can not be changed later. The rest is shared among Delegators
+                        including the Operator&apos;s own stake.
+                    </p>
+                </Hint>
+                <ul>
+                    <li>
+                        <Prop>Operator ID</Prop>
+                        <div>{operatorId}</div>
+                    </li>
+                </ul>
+            </Section>
+        </FormModal>
+    )
+}

--- a/src/modals/BecomeOperatorModal.tsx
+++ b/src/modals/BecomeOperatorModal.tsx
@@ -17,7 +17,8 @@ interface Props extends Omit<FormModalProps, 'canSubmit'> {
     operatorId?: string
     onResolve?: (cut: number) => void
     cut?: number
-    balance: string
+    balance?: string
+    tokenSymbol?: string
 }
 
 export default function BecomeOperatorModal({
@@ -27,6 +28,7 @@ export default function BecomeOperatorModal({
     onResolve,
     operatorId = 'N/A',
     cut: cutProp,
+    tokenSymbol = 'DATA',
     ...props
 }: Props) {
     const [busy, setBusy] = useState(false)
@@ -107,7 +109,9 @@ export default function BecomeOperatorModal({
                 <ul>
                     <li>
                         <Prop>Your wallet balance</Prop>
-                        <div>{balance} DATA</div>
+                        <div>
+                            {balance} {tokenSymbol}
+                        </div>
                     </li>
                     <li>
                         <Prop>Operator ID</Prop>

--- a/src/modals/BecomeOperatorModal.tsx
+++ b/src/modals/BecomeOperatorModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import BigNumber from 'bignumber.js'
 import { RejectionReason } from '$app/src/modals/BaseModal'
 import FormModal, {
     FieldWrap,
@@ -16,11 +17,13 @@ interface Props extends Omit<FormModalProps, 'canSubmit'> {
     operatorId?: string
     onResolve?: (cut: number) => void
     cut?: number
+    balance: string
 }
 
 export default function BecomeOperatorModal({
     title = 'Become an Operator',
     submitLabel = 'Become an Operator',
+    balance: balanceProp = '0',
     onResolve,
     operatorId = 'N/A',
     cut: cutProp,
@@ -42,6 +45,8 @@ export default function BecomeOperatorModal({
 
     const canSubmit =
         `${numericValue}` === value && numericValue >= 0 && numericValue <= 100
+
+    const balance = new BigNumber(balanceProp).dividedBy(1e18).toString()
 
     return (
         <FormModal
@@ -73,9 +78,11 @@ export default function BecomeOperatorModal({
                 }
             }}
         >
-            <SectionHeadline>Please choose your Operator&apos;s cut</SectionHeadline>
+            <SectionHeadline>
+                Please choose the percentage for the Operator&apos;s cut
+            </SectionHeadline>
             <Section>
-                <Label>Operator&apos;s cut</Label>
+                <Label>Operator&apos;s cut percentage</Label>
                 <FieldWrap>
                     <TextInput
                         name="cut"
@@ -98,6 +105,10 @@ export default function BecomeOperatorModal({
                     </p>
                 </Hint>
                 <ul>
+                    <li>
+                        <Prop>Your wallet balance</Prop>
+                        <div>{balance} DATA</div>
+                    </li>
                     <li>
                         <Prop>Operator ID</Prop>
                         <div>{operatorId}</div>

--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -97,8 +97,6 @@ export default function CreateSponsorshipModal({
 
     const balance = new BigNumber(balanceProp)
 
-    const extensionInDays = 0
-
     const initialRawFormData = getRawFormData(formDataProp)
 
     const [
@@ -119,11 +117,13 @@ export default function CreateSponsorshipModal({
         initialRawFormData,
     )
 
-    const initialAmount = new BigNumber(rawInitialAmount || '0')
-        .multipliedBy(1e18)
-        .toString()
+    const initialAmountBN = new BigNumber(rawInitialAmount || '0').multipliedBy(1e18)
 
-    const payoutRate = new BigNumber(rawPayoutRate || '0').multipliedBy(1e18).toString()
+    const initialAmount = initialAmountBN.toString()
+
+    const payoutRateBN = new BigNumber(rawPayoutRate || '0').multipliedBy(1e18)
+
+    const payoutRate = payoutRateBN.toString()
 
     const minStakeDuration = rawMinStakeDuration || '0'
 
@@ -156,6 +156,11 @@ export default function CreateSponsorshipModal({
         minStakeDuration === (initialRawFormData.minStakeDuration || '0') &&
         minNumberOfOperators === (initialRawFormData.minNumberOfOperators || '0') &&
         maxNumberOfOperators === (initialRawFormData.maxNumberOfOperators || '0')
+
+    const extensionInDays =
+        payoutRateBN.isGreaterThan(0) && initialAmountBN.isGreaterThanOrEqualTo(0)
+            ? initialAmountBN.dividedBy(payoutRateBN).toNumber()
+            : 0
 
     return (
         <FormModal
@@ -262,7 +267,10 @@ export default function CreateSponsorshipModal({
                         <TextAppendix>DATA/day</TextAppendix>
                     </FieldWrap>
                     <Hint>
-                        <p>The Sponsorship will be funded for {extensionInDays} days</p>
+                        <p>
+                            The Sponsorship will be funded for{' '}
+                            {extensionInDays.toFixed(2).replace(/\.00$/, '')} days
+                        </p>
                     </Hint>
                 </Section>
                 <Section>

--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -1,0 +1,328 @@
+import React, { useEffect, useReducer, useState } from 'react'
+import BigNumber from 'bignumber.js'
+import { z } from 'zod'
+import { RejectionReason } from '$app/src/modals/BaseModal'
+import FormModal, {
+    FieldWrap,
+    FormModalProps,
+    Group,
+    GroupHeadline,
+    Hint,
+    Prop,
+    Section,
+    SectionHeadline,
+    TextAppendix,
+    TextInput,
+} from '$app/src/modals/FormModal'
+import Label from '$ui/Label'
+
+interface RawFormData {
+    streamId: string
+    initialAmount: string
+    payoutRate: string
+    minStakeDuration: string
+    minNumberOfOperators: string
+    maxNumberOfOperators: string
+}
+
+const FormData = z
+    .object({
+        streamId: z.string().trim().min(1),
+        initialAmount: z
+            .string()
+            .refine((value) => new BigNumber(value).isGreaterThanOrEqualTo(0)),
+        payoutRate: z.string().refine((value) => new BigNumber(value).isGreaterThan(0)),
+        minStakeDuration: z
+            .number()
+            .gte(0)
+            .refine((value) => Number.isSafeInteger(value)),
+        minNumberOfOperators: z
+            .number()
+            .gte(0)
+            .refine((value) => Number.isSafeInteger(value)),
+        maxNumberOfOperators: z
+            .number()
+            .gte(0)
+            .refine((value) => Number.isSafeInteger(value)),
+    })
+    .refine(
+        ({ minNumberOfOperators, maxNumberOfOperators }) =>
+            maxNumberOfOperators >= minNumberOfOperators,
+        {
+            message: 'invalid range of operator numbers',
+        },
+    )
+
+type FormData = z.infer<typeof FormData>
+
+interface Props extends Omit<FormModalProps, 'canSubmit'> {
+    onResolve?: (formData: FormData) => void
+    balance?: string
+    formData: Partial<FormData>
+}
+
+function getRawFormData(formData: Partial<FormData>): RawFormData {
+    return {
+        initialAmount: !formData.initialAmount
+            ? ''
+            : new BigNumber(formData.initialAmount).dividedBy(1e18).toString(),
+        streamId: formData.streamId || '',
+        payoutRate: !formData.payoutRate
+            ? ''
+            : new BigNumber(formData.payoutRate).dividedBy(1e18).toString(),
+        minStakeDuration:
+            typeof formData.minStakeDuration === 'undefined'
+                ? ''
+                : `${formData.minStakeDuration}`,
+        minNumberOfOperators:
+            typeof formData.minNumberOfOperators === 'undefined'
+                ? ''
+                : `${formData.minNumberOfOperators}`,
+        maxNumberOfOperators:
+            typeof formData.maxNumberOfOperators === 'undefined'
+                ? ''
+                : `${formData.maxNumberOfOperators}`,
+    }
+}
+
+export default function CreateSponsorshipModal({
+    title = 'Create Sponsorship',
+    submitLabel = 'Create',
+    onResolve,
+    balance: balanceProp = '0',
+    formData: formDataProp = {},
+    ...props
+}: Props) {
+    const [busy, setBusy] = useState(false)
+
+    const balance = new BigNumber(balanceProp)
+
+    const extensionInDays = 0
+
+    const initialRawFormData = getRawFormData(formDataProp)
+
+    const [
+        {
+            initialAmount: rawInitialAmount,
+            streamId: rawStreamId,
+            payoutRate: rawPayoutRate,
+            minStakeDuration: rawMinStakeDuration,
+            minNumberOfOperators: rawMinNumberOfOperators,
+            maxNumberOfOperators: rawMaxNumberOfOperators,
+        },
+        setRawProperties,
+    ] = useReducer<(state: RawFormData, change: Partial<RawFormData>) => RawFormData>(
+        (state, change) => ({
+            ...state,
+            ...change,
+        }),
+        initialRawFormData,
+    )
+
+    const initialAmount = new BigNumber(rawInitialAmount || '0')
+        .multipliedBy(1e18)
+        .toString()
+
+    const payoutRate = new BigNumber(rawPayoutRate || '0').multipliedBy(1e18).toString()
+
+    const minStakeDuration = rawMinStakeDuration || '0'
+
+    const minNumberOfOperators = rawMinNumberOfOperators || '0'
+
+    const maxNumberOfOperators = rawMaxNumberOfOperators || '0'
+
+    /**
+     * @TODO Implement a search feature and a dropdown.
+     */
+    const streamId = rawStreamId
+
+    const formData: FormData = {
+        streamId,
+        initialAmount,
+        payoutRate,
+        minStakeDuration: Number.parseInt(minStakeDuration),
+        minNumberOfOperators: Number.parseInt(minNumberOfOperators),
+        maxNumberOfOperators: Number.parseInt(maxNumberOfOperators),
+    }
+
+    const canSubmit = FormData.safeParse(formData).success
+
+    const backdropDismissable =
+        rawStreamId === initialRawFormData.streamId &&
+        new BigNumber(rawInitialAmount || '0').toString() ===
+            new BigNumber(initialRawFormData.initialAmount || '0').toString() &&
+        new BigNumber(rawPayoutRate || '0').toString() ===
+            new BigNumber(initialRawFormData.payoutRate || '0').toString() &&
+        minStakeDuration === (initialRawFormData.minStakeDuration || '0') &&
+        minNumberOfOperators === (initialRawFormData.minNumberOfOperators || '0') &&
+        maxNumberOfOperators === (initialRawFormData.maxNumberOfOperators || '0')
+
+    return (
+        <FormModal
+            {...props}
+            title={title}
+            canSubmit={canSubmit && !busy}
+            submitLabel={submitLabel}
+            submitting={busy}
+            onBeforeAbort={(reason) =>
+                !busy && (backdropDismissable || reason !== RejectionReason.Backdrop)
+            }
+            onSubmit={async () => {
+                if (!canSubmit) {
+                    return
+                }
+
+                setBusy(true)
+
+                try {
+                    /**
+                     * Replace the following with your favourite contract interaction! <3
+                     */
+                    await new Promise((resolve) => void setTimeout(resolve, 2000))
+
+                    onResolve?.(formData)
+                } catch (e) {
+                    console.warn('Error while becoming an operator', e)
+                    setBusy(false)
+                } finally {
+                    /**
+                     * No need to reset `busy`. `onResolve` makes the whole modal disappear.
+                     */
+                }
+            }}
+        >
+            <Group>
+                <GroupHeadline>Select a Stream</GroupHeadline>
+                <SectionHeadline>
+                    Your Sponsorship will incentivize nodes to relay and secure this
+                    stream
+                </SectionHeadline>
+                <Section>
+                    <Label>Select a Stream</Label>
+                    <FieldWrap>
+                        <TextInput
+                            name="streamId"
+                            autoFocus
+                            onChange={({ target }) =>
+                                void setRawProperties({
+                                    streamId: target.value,
+                                })
+                            }
+                            placeholder="Type to select a stream"
+                            readOnly={busy}
+                            type="text"
+                            value={streamId}
+                        />
+                    </FieldWrap>
+                </Section>
+            </Group>
+            <Group>
+                <GroupHeadline>Set Sponsorship parameters</GroupHeadline>
+                <Section>
+                    <Label>Initial amount to fund</Label>
+                    <FieldWrap>
+                        <TextInput
+                            name="initialAmount"
+                            onChange={({ target }) =>
+                                void setRawProperties({
+                                    initialAmount: target.value,
+                                })
+                            }
+                            placeholder="0"
+                            readOnly={busy}
+                            type="number"
+                            min={0}
+                            value={rawInitialAmount}
+                        />
+                        <TextAppendix>DATA</TextAppendix>
+                    </FieldWrap>
+                    <Hint>
+                        <p>
+                            Wallet balance:{' '}
+                            <strong>{balance.dividedBy(1e18).toString()} DATA</strong>
+                        </p>
+                    </Hint>
+                </Section>
+                <Section>
+                    <Label>Payout rate*</Label>
+                    <FieldWrap>
+                        <TextInput
+                            name="payoutRate"
+                            onChange={({ target }) =>
+                                void setRawProperties({
+                                    payoutRate: target.value,
+                                })
+                            }
+                            placeholder="0"
+                            readOnly={busy}
+                            type="number"
+                            min={0}
+                            value={rawPayoutRate}
+                        />
+                        <TextAppendix>DATA/day</TextAppendix>
+                    </FieldWrap>
+                    <Hint>
+                        <p>The Sponsorship will be funded for {extensionInDays} days</p>
+                    </Hint>
+                </Section>
+                <Section>
+                    <Label>Minimum time Operators must stay staked</Label>
+                    <FieldWrap>
+                        <TextInput
+                            name="minStakeDuration"
+                            onChange={({ target }) =>
+                                void setRawProperties({
+                                    minStakeDuration: target.value,
+                                })
+                            }
+                            placeholder="0"
+                            readOnly={busy}
+                            type="number"
+                            min={0}
+                            value={rawMinStakeDuration}
+                        />
+                        <TextAppendix>Days</TextAppendix>
+                    </FieldWrap>
+                </Section>
+                <Section>
+                    <Label>Minimum number of Operators</Label>
+                    <FieldWrap>
+                        <TextInput
+                            name="minNumberOfOperators"
+                            onChange={({ target }) =>
+                                void setRawProperties({
+                                    minNumberOfOperators: target.value,
+                                })
+                            }
+                            placeholder="0"
+                            readOnly={busy}
+                            type="number"
+                            min={0}
+                            value={rawMinNumberOfOperators}
+                        />
+                        <TextAppendix>Operators</TextAppendix>
+                    </FieldWrap>
+                </Section>
+                <Section>
+                    <Label>Maximum number of Operators</Label>
+                    <FieldWrap>
+                        <TextInput
+                            name="maxNumberOfOperators"
+                            onChange={({ target }) =>
+                                void setRawProperties({
+                                    maxNumberOfOperators: target.value,
+                                })
+                            }
+                            placeholder="0"
+                            readOnly={busy}
+                            type="number"
+                            min={0}
+                            value={rawMaxNumberOfOperators}
+                        />
+                        <TextAppendix>Operators</TextAppendix>
+                    </FieldWrap>
+                </Section>
+            </Group>
+        </FormModal>
+    )
+}

--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -61,6 +61,7 @@ interface Props extends Omit<FormModalProps, 'canSubmit'> {
     onResolve?: (formData: FormData) => void
     balance?: string
     formData: Partial<FormData>
+    tokenSymbol?: string
 }
 
 function getRawFormData(formData: Partial<FormData>): RawFormData {
@@ -93,6 +94,7 @@ export default function CreateSponsorshipModal({
     onResolve,
     balance: balanceProp = '0',
     formData: formDataProp = {},
+    tokenSymbol = 'DATA',
     ...props
 }: Props) {
     const [busy, setBusy] = useState(false)
@@ -244,12 +246,14 @@ export default function CreateSponsorshipModal({
                             min={0}
                             value={rawInitialAmount}
                         />
-                        <TextAppendix>DATA</TextAppendix>
+                        <TextAppendix>{tokenSymbol}</TextAppendix>
                     </FieldWrap>
                     <Hint>
                         <p>
                             Wallet balance:{' '}
-                            <strong>{balance.dividedBy(1e18).toString()} DATA</strong>
+                            <strong>
+                                {balance.dividedBy(1e18).toString()} {tokenSymbol}
+                            </strong>
                         </p>
                     </Hint>
                 </Section>
@@ -269,7 +273,7 @@ export default function CreateSponsorshipModal({
                             min={0}
                             value={rawPayoutRate}
                         />
-                        <TextAppendix>DATA/day</TextAppendix>
+                        <TextAppendix>{tokenSymbol}/day</TextAppendix>
                     </FieldWrap>
                     <Hint>
                         <p>

--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useReducer, useState } from 'react'
 import BigNumber from 'bignumber.js'
 import { z } from 'zod'
+import SearchIcon from '@atlaskit/icon/glyph/search'
 import { RejectionReason } from '$app/src/modals/BaseModal'
 import FormModal, {
     FieldWrap,
@@ -8,6 +9,7 @@ import FormModal, {
     Group,
     GroupHeadline,
     Hint,
+    IconWrapAppendix,
     Prop,
     Section,
     SectionHeadline,
@@ -218,6 +220,9 @@ export default function CreateSponsorshipModal({
                             type="text"
                             value={streamId}
                         />
+                        <IconWrapAppendix>
+                            <SearchIcon label="Search" />
+                        </IconWrapAppendix>
                     </FieldWrap>
                 </Section>
             </Group>

--- a/src/modals/DelegateFundsModal.tsx
+++ b/src/modals/DelegateFundsModal.tsx
@@ -16,6 +16,7 @@ import Label from '$ui/Label'
 interface Props extends Omit<FormModalProps, 'canSubmit'> {
     onResolve?: (amount: string) => void
     balance?: string
+    tokenSymbol?: string
     delegatedTotal?: string
     operatorId?: string
     amount?: string
@@ -24,6 +25,7 @@ interface Props extends Omit<FormModalProps, 'canSubmit'> {
 export default function DelegateFundsModal({
     title = 'Delegate',
     balance: balanceProp = '0',
+    tokenSymbol = 'DATA',
     delegatedTotal: delegatedTotalProp = '0',
     operatorId = 'N/A',
     onResolve,
@@ -83,7 +85,8 @@ export default function DelegateFundsModal({
             }}
         >
             <SectionHeadline>
-                Please set the amount of DATA to delegate to the selected Operator
+                Please set the amount of {tokenSymbol} to delegate to the selected
+                Operator
             </SectionHeadline>
             <Section>
                 <Label>Amount to delegate</Label>
@@ -98,7 +101,7 @@ export default function DelegateFundsModal({
                         min={0}
                         value={rawAmount}
                     />
-                    <TextAppendix>DATA</TextAppendix>
+                    <TextAppendix>{tokenSymbol}</TextAppendix>
                 </FieldWrap>
                 <ul>
                     <li>
@@ -109,7 +112,9 @@ export default function DelegateFundsModal({
                                 <>Your wallet balance</>
                             )}
                         </Prop>
-                        <div>{balance.dividedBy(1e18).toString()} DATA</div>
+                        <div>
+                            {balance.dividedBy(1e18).toString()} {tokenSymbol}
+                        </div>
                     </li>
                     <li>
                         <Prop>Operator ID</Prop>
@@ -117,7 +122,9 @@ export default function DelegateFundsModal({
                     </li>
                     <li>
                         <Prop>Amount currently delegated to Operator</Prop>
-                        <div>{delegatedTotal.dividedBy(1e18).toString()} DATA</div>
+                        <div>
+                            {delegatedTotal.dividedBy(1e18).toString()} {tokenSymbol}
+                        </div>
                     </li>
                 </ul>
             </Section>

--- a/src/modals/DelegateFundsModal.tsx
+++ b/src/modals/DelegateFundsModal.tsx
@@ -1,0 +1,126 @@
+import BigNumber from 'bignumber.js'
+import React, { useEffect, useState } from 'react'
+import { RejectionReason } from '$app/src/modals/BaseModal'
+import FormModal, {
+    FieldWrap,
+    FormModalProps,
+    Hint,
+    Prop,
+    Section,
+    SectionHeadline,
+    TextAppendix,
+    TextInput,
+} from '$app/src/modals/FormModal'
+import Label from '$ui/Label'
+
+interface Props extends Omit<FormModalProps, 'canSubmit'> {
+    onResolve?: (amount: string) => void
+    balance?: string
+    delegatedTotal?: string
+    operatorId?: string
+    amount?: string
+}
+
+export default function DelegateFundsModal({
+    title = 'Delegate',
+    balance: balanceProp = '0',
+    delegatedTotal: delegatedTotalProp = '0',
+    operatorId = 'N/A',
+    onResolve,
+    amount: amountProp = '',
+    submitLabel = 'Delegate',
+    ...props
+}: Props) {
+    const [rawAmount, setRawAmount] = useState(amountProp)
+
+    useEffect(() => {
+        setRawAmount(amountProp)
+    }, [amountProp])
+
+    const value = rawAmount || '0'
+
+    const finalValue = new BigNumber(value).multipliedBy(1e18)
+
+    const balance = new BigNumber(balanceProp)
+
+    const delegatedTotal = new BigNumber(delegatedTotalProp)
+
+    const insufficientFunds = finalValue.isGreaterThan(balance)
+
+    const canSubmit =
+        finalValue.isFinite() && finalValue.isGreaterThan(0) && !insufficientFunds
+
+    const [busy, setBusy] = useState(false)
+
+    return (
+        <FormModal
+            {...props}
+            title={title}
+            canSubmit={canSubmit && !busy}
+            submitting={busy}
+            submitLabel={submitLabel}
+            onBeforeAbort={(reason) =>
+                !busy && (rawAmount === amountProp || reason !== RejectionReason.Backdrop)
+            }
+            onSubmit={async () => {
+                setBusy(true)
+
+                try {
+                    /**
+                     * Replace the following with your favourite contract interaction! <3
+                     */
+                    await new Promise((resolve) => void setTimeout(resolve, 2000))
+
+                    onResolve?.(finalValue.toString())
+                } catch (e) {
+                    console.warn('Error while delegating funds', e)
+                    setBusy(false)
+                } finally {
+                    /**
+                     * No need to reset `busy`. `onResolve` makes the whole modal disappear.
+                     */
+                }
+            }}
+        >
+            <SectionHeadline>
+                Please set the amount of DATA to delegate to the selected Operator
+            </SectionHeadline>
+            <Section>
+                <Label>Amount to delegate</Label>
+                <FieldWrap $invalid={insufficientFunds}>
+                    <TextInput
+                        name="amount"
+                        autoFocus
+                        onChange={({ target }) => void setRawAmount(target.value)}
+                        placeholder="0"
+                        readOnly={busy}
+                        type="number"
+                        min={0}
+                        value={rawAmount}
+                    />
+                    <TextAppendix>DATA</TextAppendix>
+                </FieldWrap>
+                <ul>
+                    <li>
+                        <Prop $invalid={insufficientFunds}>
+                            {insufficientFunds ? (
+                                <>Not enough balance in your wallet</>
+                            ) : (
+                                <>Your wallet balance</>
+                            )}
+                        </Prop>
+                        <div>{balance.dividedBy(1e18).toString()} DATA</div>
+                    </li>
+                    <li>
+                        <Prop>Operator ID</Prop>
+                        <div>{operatorId}</div>
+                    </li>
+                    <li>
+                        <Prop>Amount currently delegated to Operator</Prop>
+                        <div>{delegatedTotal.dividedBy(1e18).toString()} DATA</div>
+                    </li>
+                </ul>
+            </Section>
+        </FormModal>
+    )
+}

--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -16,6 +16,7 @@ import Label from '$ui/Label'
 interface Props extends Omit<FormModalProps, 'canSubmit'> {
     onResolve?: (amount: string) => void
     balance?: string
+    tokenSymbol?: string
     delegatedTotal?: string
     operatorId?: string
     amount?: string
@@ -27,6 +28,7 @@ const DayInSeconds = 60 * 60 * 24
 export default function FundSponsorshipModal({
     title = 'Fund Sponsorship',
     balance: balanceProp = '0',
+    tokenSymbol = 'DATA',
     onResolve,
     amount: amountProp = '',
     submitLabel = 'Fund',
@@ -94,7 +96,7 @@ export default function FundSponsorshipModal({
             }}
         >
             <SectionHeadline>
-                Please set the amount of DATA to spend to extend the Sponsorship
+                Please set the amount of {tokenSymbol} to spend to extend the Sponsorship
             </SectionHeadline>
             <Section>
                 <Label>Amount to delegate</Label>
@@ -109,7 +111,7 @@ export default function FundSponsorshipModal({
                         min={0}
                         value={rawAmount}
                     />
-                    <TextAppendix>DATA</TextAppendix>
+                    <TextAppendix>{tokenSymbol}</TextAppendix>
                 </FieldWrap>
                 <ul>
                     <li>
@@ -120,7 +122,9 @@ export default function FundSponsorshipModal({
                                 <>Your wallet balance</>
                             )}
                         </Prop>
-                        <div>{balance.dividedBy(1e18).toString()} DATA</div>
+                        <div>
+                            {balance.dividedBy(1e18).toString()} {tokenSymbol}
+                        </div>
                     </li>
                     <li>
                         <Prop>Sponsorship extended by</Prop>
@@ -132,7 +136,9 @@ export default function FundSponsorshipModal({
                     </li>
                     <li>
                         <Prop>Rate</Prop>
-                        <div>{rate.toString()} DATA/day</div>
+                        <div>
+                            {rate.toString()} {tokenSymbol}/day
+                        </div>
                     </li>
                 </ul>
             </Section>

--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -1,0 +1,141 @@
+import BigNumber from 'bignumber.js'
+import React, { useEffect, useState } from 'react'
+import moment from 'moment'
+import { RejectionReason } from '$app/src/modals/BaseModal'
+import FormModal, {
+    FieldWrap,
+    FormModalProps,
+    Prop,
+    Section,
+    SectionHeadline,
+    TextAppendix,
+    TextInput,
+} from '$app/src/modals/FormModal'
+import Label from '$ui/Label'
+
+interface Props extends Omit<FormModalProps, 'canSubmit'> {
+    onResolve?: (amount: string) => void
+    balance?: string
+    delegatedTotal?: string
+    operatorId?: string
+    amount?: string
+    pricePerSecond?: string
+}
+
+const DayInSeconds = 60 * 60 * 24
+
+export default function FundSponsorshipModal({
+    title = 'Fund Sponsorship',
+    balance: balanceProp = '0',
+    onResolve,
+    amount: amountProp = '',
+    submitLabel = 'Fund',
+    pricePerSecond: pricePerSecondProp = '0',
+    ...props
+}: Props) {
+    const [rawAmount, setRawAmount] = useState(amountProp)
+
+    const pricePerSecond = new BigNumber(pricePerSecondProp)
+
+    const rate = pricePerSecond.dividedBy(1e18).multipliedBy(DayInSeconds)
+
+    useEffect(() => {
+        setRawAmount(amountProp)
+    }, [amountProp])
+
+    const value = rawAmount || '0'
+
+    const finalValue = new BigNumber(value).multipliedBy(1e18)
+
+    const extensionInSeconds =
+        pricePerSecond.isGreaterThan(0) && finalValue.isGreaterThanOrEqualTo(0)
+            ? finalValue.dividedBy(pricePerSecond).toNumber()
+            : 0
+
+    const endDate = new Date(Date.now() + extensionInSeconds * 1000)
+
+    const balance = new BigNumber(balanceProp)
+
+    const insufficientFunds = finalValue.isGreaterThan(balance)
+
+    const canSubmit =
+        finalValue.isFinite() && finalValue.isGreaterThan(0) && !insufficientFunds
+
+    const [busy, setBusy] = useState(false)
+
+    return (
+        <FormModal
+            {...props}
+            title={title}
+            canSubmit={canSubmit && !busy}
+            submitting={busy}
+            submitLabel={submitLabel}
+            onBeforeAbort={(reason) =>
+                !busy && (rawAmount === amountProp || reason !== RejectionReason.Backdrop)
+            }
+            onSubmit={async () => {
+                setBusy(true)
+
+                try {
+                    /**
+                     * Replace the following with your favourite contract interaction! <3
+                     */
+                    await new Promise((resolve) => void setTimeout(resolve, 2000))
+
+                    onResolve?.(finalValue.toString())
+                } catch (e) {
+                    console.warn('Error while funding sponsorship', e)
+                    setBusy(false)
+                } finally {
+                    /**
+                     * No need to reset `busy`. `onResolve` makes the whole modal disappear.
+                     */
+                }
+            }}
+        >
+            <SectionHeadline>
+                Please set the amount of DATA to spend to extend the Sponsorship
+            </SectionHeadline>
+            <Section>
+                <Label>Amount to delegate</Label>
+                <FieldWrap $invalid={insufficientFunds}>
+                    <TextInput
+                        name="amount"
+                        autoFocus
+                        onChange={({ target }) => void setRawAmount(target.value)}
+                        placeholder="0"
+                        readOnly={busy}
+                        type="number"
+                        min={0}
+                        value={rawAmount}
+                    />
+                    <TextAppendix>DATA</TextAppendix>
+                </FieldWrap>
+                <ul>
+                    <li>
+                        <Prop $invalid={insufficientFunds}>
+                            {insufficientFunds ? (
+                                <>Not enough balance in your wallet</>
+                            ) : (
+                                <>Your wallet balance</>
+                            )}
+                        </Prop>
+                        <div>{balance.dividedBy(1e18).toString()} DATA</div>
+                    </li>
+                    <li>
+                        <Prop>Sponsorship extended by</Prop>
+                        <div>{extensionInSeconds / DayInSeconds} days</div>
+                    </li>
+                    <li>
+                        <Prop>New end date</Prop>
+                        <div>{moment(endDate).format('YYYY-MM-DD')}</div>
+                    </li>
+                    <li>
+                        <Prop>Rate</Prop>
+                        <div>{rate.toString()} DATA/day</div>
+                    </li>
+                </ul>
+            </Section>
+        </FormModal>
+    )
+}

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -62,7 +62,9 @@ export default function JoinSponsorshipModal({
         setRawAmount(parseAmount(amountProp))
     }, [amountProp])
 
-    const canSubmit = finalAmount.isGreaterThan(0)
+    const insufficientFunds = finalAmount.isGreaterThan(operatorBalance)
+
+    const canSubmit = finalAmount.isGreaterThan(0) && !insufficientFunds
 
     const { copy } = useCopy()
 
@@ -143,7 +145,13 @@ export default function JoinSponsorshipModal({
                 </FieldWrap>
                 <ul>
                     <li>
-                        <Prop>Available balance in Operator contract</Prop>
+                        <Prop $invalid={insufficientFunds}>
+                            {insufficientFunds ? (
+                                <>Not enough balance in Operator contract</>
+                            ) : (
+                                <>Available balance in Operator contract</>
+                            )}
+                        </Prop>
                         <div>
                             {operatorBalance.dividedBy(1e18).toString()} {tokenSymbol}
                         </div>

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -22,6 +22,7 @@ import useCopy from '$shared/hooks/useCopy'
 interface Props extends Omit<FormModalProps, 'canSubmit'> {
     onResolve?: (amount: string) => void
     operatorBalance?: string
+    tokenSymbol?: string
     operatorId?: string
     amount?: string
     streamId?: string
@@ -41,6 +42,7 @@ export default function JoinSponsorshipModal({
     operatorId = 'N/A',
     amount: amountProp = '0',
     streamId: streamIdProp,
+    tokenSymbol = 'DATA',
     ...props
 }: Props) {
     const streamId = streamIdProp || 'N/A'
@@ -103,7 +105,8 @@ export default function JoinSponsorshipModal({
             }}
         >
             <SectionHeadline>
-                Please set the amount of DATA to stake on the selected Sponsorship
+                Please set the amount of {tokenSymbol} to stake on the selected
+                Sponsorship
             </SectionHeadline>
             <Section>
                 <Label>Sponsorship Stream ID</Label>
@@ -136,12 +139,14 @@ export default function JoinSponsorshipModal({
                         min={0}
                         value={rawAmount}
                     />
-                    <TextAppendix>DATA</TextAppendix>
+                    <TextAppendix>{tokenSymbol}</TextAppendix>
                 </FieldWrap>
                 <ul>
                     <li>
                         <Prop>Available balance in Operator contract</Prop>
-                        <div>{operatorBalance.dividedBy(1e18).toString()} DATA</div>
+                        <div>
+                            {operatorBalance.dividedBy(1e18).toString()} {tokenSymbol}
+                        </div>
                     </li>
                     <li>
                         <Prop>Operator ID</Prop>

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useReducer, useState } from 'react'
+import BigNumber from 'bignumber.js'
+import { z } from 'zod'
+import { RejectionReason } from '$app/src/modals/BaseModal'
+import FormModal, {
+    FieldWrap,
+    FormModalProps,
+    Group,
+    GroupHeadline,
+    Hint,
+    Prop,
+    Section,
+    SectionHeadline,
+    TextAppendix,
+    TextInput,
+} from '$app/src/modals/FormModal'
+import Label from '$ui/Label'
+
+interface Props extends Omit<FormModalProps, 'canSubmit'> {
+    onResolve?: (amount: string) => void
+    operatorBalance?: string
+    operatorId?: string
+    amount?: string
+    streamId?: string
+}
+
+function parseAmount(amount: string | undefined) {
+    return typeof amount === 'undefined' || /^0?$/.test(amount)
+        ? ''
+        : new BigNumber(amount).dividedBy(1e18).toString()
+}
+
+export default function JoinSponsorshipModal({
+    title = 'Join Sponsorship as Operator',
+    submitLabel = 'Join',
+    onResolve,
+    operatorBalance: operatorBalanceProp = '0',
+    operatorId = 'N/A',
+    amount: amountProp = '0',
+    streamId = 'N/A',
+    ...props
+}: Props) {
+    const [busy, setBusy] = useState(false)
+
+    const operatorBalance = new BigNumber(operatorBalanceProp)
+
+    const [rawAmount, setRawAmount] = useState(parseAmount(amountProp))
+
+    const amount = new BigNumber(rawAmount || '0').multipliedBy(1e18)
+
+    const finalAmount =
+        amount.isFinite() && amount.isGreaterThan(0) ? amount : new BigNumber(0)
+
+    useEffect(() => {
+        setRawAmount(parseAmount(amountProp))
+    }, [amountProp])
+
+    const canSubmit = finalAmount.isGreaterThan(0)
+
+    return (
+        <FormModal
+            {...props}
+            title={title}
+            canSubmit={canSubmit && !busy}
+            submitLabel={submitLabel}
+            submitting={busy}
+            onBeforeAbort={(reason) =>
+                !busy &&
+                (new BigNumber(rawAmount || '0')
+                    .multipliedBy(1e18)
+                    .eq(amountProp || '0') ||
+                    reason !== RejectionReason.Backdrop)
+            }
+            onSubmit={async () => {
+                if (!canSubmit) {
+                    return
+                }
+
+                setBusy(true)
+
+                try {
+                    /**
+                     * Replace the following with your favourite contract interaction! <3
+                     */
+                    await new Promise((resolve) => void setTimeout(resolve, 2000))
+
+                    onResolve?.(finalAmount.toString())
+                } catch (e) {
+                    console.warn('Error while becoming an operator', e)
+                    setBusy(false)
+                } finally {
+                    /**
+                     * No need to reset `busy`. `onResolve` makes the whole modal disappear.
+                     */
+                }
+            }}
+        >
+            <SectionHeadline>
+                Please set the amount of DATA to stake on the selected Sponsorship
+            </SectionHeadline>
+            <Section>
+                <Label>Sponsorship Stream ID</Label>
+                <FieldWrap>
+                    <TextInput defaultValue={streamId} readOnly />
+                </FieldWrap>
+                <Label>Amount to stake</Label>
+                <FieldWrap>
+                    <TextInput
+                        autoFocus
+                        name="amount"
+                        onChange={({ target }) => void setRawAmount(target.value)}
+                        placeholder="0"
+                        readOnly={busy}
+                        type="number"
+                        min={0}
+                        value={rawAmount}
+                    />
+                    <TextAppendix>DATA</TextAppendix>
+                </FieldWrap>
+                <ul>
+                    <li>
+                        <Prop>Available balance in Operator contract</Prop>
+                        <div>{operatorBalance.dividedBy(1e18).toString()} DATA</div>
+                    </li>
+                    <li>
+                        <Prop>Operator ID</Prop>
+                        <div>{operatorId}</div>
+                    </li>
+                </ul>
+            </Section>
+        </FormModal>
+    )
+}

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useReducer, useState } from 'react'
 import BigNumber from 'bignumber.js'
+import CopyIcon from '@atlaskit/icon/glyph/copy'
 import { z } from 'zod'
 import { RejectionReason } from '$app/src/modals/BaseModal'
 import FormModal, {
@@ -13,8 +14,10 @@ import FormModal, {
     SectionHeadline,
     TextAppendix,
     TextInput,
+    CopyButtonWrapAppendix,
 } from '$app/src/modals/FormModal'
 import Label from '$ui/Label'
+import useCopy from '$shared/hooks/useCopy'
 
 interface Props extends Omit<FormModalProps, 'canSubmit'> {
     onResolve?: (amount: string) => void
@@ -37,9 +40,11 @@ export default function JoinSponsorshipModal({
     operatorBalance: operatorBalanceProp = '0',
     operatorId = 'N/A',
     amount: amountProp = '0',
-    streamId = 'N/A',
+    streamId: streamIdProp,
     ...props
 }: Props) {
+    const streamId = streamIdProp || 'N/A'
+
     const [busy, setBusy] = useState(false)
 
     const operatorBalance = new BigNumber(operatorBalanceProp)
@@ -56,6 +61,8 @@ export default function JoinSponsorshipModal({
     }, [amountProp])
 
     const canSubmit = finalAmount.isGreaterThan(0)
+
+    const { copy } = useCopy()
 
     return (
         <FormModal
@@ -100,8 +107,22 @@ export default function JoinSponsorshipModal({
             </SectionHeadline>
             <Section>
                 <Label>Sponsorship Stream ID</Label>
-                <FieldWrap>
+                <FieldWrap $grayedOut>
                     <TextInput defaultValue={streamId} readOnly />
+                    {!!streamIdProp && (
+                        <CopyButtonWrapAppendix>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    copy(streamIdProp, {
+                                        toastMessage: 'Copied!',
+                                    })
+                                }}
+                            >
+                                <CopyIcon label="Copy" size="small" />
+                            </button>
+                        </CopyButtonWrapAppendix>
+                    )}
                 </FieldWrap>
                 <Label>Amount to stake</Label>
                 <FieldWrap>

--- a/src/pages/OperatorsPage/index.tsx
+++ b/src/pages/OperatorsPage/index.tsx
@@ -9,12 +9,19 @@ import { Layer } from '$app/src/utils/Layer'
 import BecomeOperatorModal from '~/modals/BecomeOperatorModal'
 import DelegateFundsModal from '~/modals/DelegateFundsModal'
 import FundSponsorshipModal from '~/modals/FundSponsorshipModal'
+import CreateSponsorshipModal from '~/modals/CreateSponsorshipModal'
+import BigNumber from 'bignumber.js'
+import JoinSponsorshipModal from '~/modals/JoinSponsorshipModal'
 
 const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)
 
 const delegateFundsModal = toaster(DelegateFundsModal, Layer.Modal)
 
 const fundSponsorshipModal = toaster(FundSponsorshipModal, Layer.Modal)
+
+const createSponsorshipModal = toaster(CreateSponsorshipModal, Layer.Modal)
+
+const joinSponsorshipModal = toaster(JoinSponsorshipModal, Layer.Modal)
 
 export default function OperatorsPage() {
     return (
@@ -34,6 +41,7 @@ export default function OperatorsPage() {
                 >
                     Become an Operator
                 </Button>
+                <br />
                 <Button
                     type="button"
                     onClick={async () => {
@@ -46,6 +54,7 @@ export default function OperatorsPage() {
                 >
                     Delegate
                 </Button>
+                <br />
                 <Button
                     type="button"
                     onClick={async () => {
@@ -57,6 +66,32 @@ export default function OperatorsPage() {
                     }}
                 >
                     Fund
+                </Button>
+                <br />
+                <Button
+                    type="button"
+                    onClick={async () => {
+                        try {
+                            await createSponsorshipModal.pop()
+                        } catch (e) {
+                            // Ignore for now.
+                        }
+                    }}
+                >
+                    Create Sponsorship
+                </Button>
+                <br />
+                <Button
+                    type="button"
+                    onClick={async () => {
+                        try {
+                            await joinSponsorshipModal.pop()
+                        } catch (e) {
+                            // Ignore for now.
+                        }
+                    }}
+                >
+                    Join Sponsorship as Operator
                 </Button>
             </PageWrap>
         </Layout>

--- a/src/pages/OperatorsPage/index.tsx
+++ b/src/pages/OperatorsPage/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { toaster } from 'toasterhea'
+import Button from '$app/src/shared/components/Button'
+import { MarketplaceHelmet } from '$app/src/shared/components/Helmet'
+import Layout from '$app/src/shared/components/Layout'
+import LoadingIndicator from '$app/src/shared/components/LoadingIndicator'
+import { PageWrap } from '$app/src/shared/components/PageWrap'
+import { Layer } from '$app/src/utils/Layer'
+import BecomeOperatorModal from '~/modals/BecomeOperatorModal'
+import DelegateFundsModal from '~/modals/DelegateFundsModal'
+import FundSponsorshipModal from '~/modals/FundSponsorshipModal'
+
+const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)
+
+const delegateFundsModal = toaster(DelegateFundsModal, Layer.Modal)
+
+const fundSponsorshipModal = toaster(FundSponsorshipModal, Layer.Modal)
+
+export default function OperatorsPage() {
+    return (
+        <Layout gray>
+            <MarketplaceHelmet title="Streams" />
+            <LoadingIndicator />
+            <PageWrap>
+                <Button
+                    type="button"
+                    onClick={async () => {
+                        try {
+                            await becomeOperatorModal.pop()
+                        } catch (e) {
+                            // Ignore for now.
+                        }
+                    }}
+                >
+                    Become an Operator
+                </Button>
+                <Button
+                    type="button"
+                    onClick={async () => {
+                        try {
+                            await delegateFundsModal.pop()
+                        } catch (e) {
+                            // Ignore for now.
+                        }
+                    }}
+                >
+                    Delegate
+                </Button>
+                <Button
+                    type="button"
+                    onClick={async () => {
+                        try {
+                            await fundSponsorshipModal.pop()
+                        } catch (e) {
+                            // Ignore for now.
+                        }
+                    }}
+                >
+                    Fund
+                </Button>
+            </PageWrap>
+        </Layout>
+    )
+}

--- a/src/pages/OperatorsPage/index.tsx
+++ b/src/pages/OperatorsPage/index.tsx
@@ -10,7 +10,6 @@ import BecomeOperatorModal from '~/modals/BecomeOperatorModal'
 import DelegateFundsModal from '~/modals/DelegateFundsModal'
 import FundSponsorshipModal from '~/modals/FundSponsorshipModal'
 import CreateSponsorshipModal from '~/modals/CreateSponsorshipModal'
-import BigNumber from 'bignumber.js'
 import JoinSponsorshipModal from '~/modals/JoinSponsorshipModal'
 
 const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)


### PR DESCRIPTION
This PR implements the following dialogs:

- Create Sponsorship
- Fund Sponsorship
- Delegate (to Operator)
- Become an Operator
- Join Sponsorship as Operator

There's also a dummy new page for Operators – `/hub/operators` – from where you can open up each of them modals.

This here is only about the visuals. I left a designated space for async logic in each of the dialogs. Additionally, each modal can take initial values for each of their input fields and resolves properly on submittion.

Cheers!

---

- [x] Stream search is a separate ticket, see [FRONT-1476](https://linear.app/streamr/issue/FRONT-1476/create-stream-selector-for-the-create-sponsorship-modal-dialog).
- [x] Move the explainer into the icon (Become an Operator modal dialog).