### PR TITLE
FRONT-1498: Respect GRANT permission in the stream editor

### DIFF
--- a/app/src/pages/AbstractStreamEditPage/AccessControlSection/index.tsx
+++ b/app/src/pages/AbstractStreamEditPage/AccessControlSection/index.tsx
@@ -12,9 +12,9 @@ export type Props = {
 const AccessControlSection: React.FunctionComponent<Props> = ({
     disabled: disabledProp,
 }) => {
-    const canEdit = useCurrentStreamAbility(StreamPermission.EDIT)
+    const canGrant = useCurrentStreamAbility(StreamPermission.GRANT)
 
-    const disabled = disabledProp || !canEdit
+    const disabled = disabledProp || !canGrant
 
     return (
         <Section title="Access control">


### PR DESCRIPTION
We let people with GRANT permission edit access options. It no longer incorrectly relies on the EDIT permission.