### PR TITLE
FRONT-1565 idempotent live nodes

### DIFF
--- a/src/hooks/useOperatorLiveNodes.ts
+++ b/src/hooks/useOperatorLiveNodes.ts
@@ -25,9 +25,17 @@ export default function useOperatorLiveNodes(operatorId: string) {
     )
 
     useEffect(() => {
+        let mounted = true
+
         setTimeout(() => {
-            setIsLoading(false)
+            if (mounted) {
+                setIsLoading(false)
+            }
         }, 15000)
+
+        return () => {
+            mounted = false
+        }
     }, [])
 
     return {

--- a/src/hooks/useOperatorLiveNodes.ts
+++ b/src/hooks/useOperatorLiveNodes.ts
@@ -1,31 +1,53 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSubscribe } from 'streamr-client-react'
+import { z } from 'zod'
+
+const HeartbeatMessage = z.object({
+    parsedContent: z.object({
+        msgType: z.literal('heartbeat'),
+        peerDescriptor: z.object({
+            id: z.string(),
+        }),
+    }),
+})
+
+type HeartbeatMessage = z.infer<typeof HeartbeatMessage>
+
+function isHeartbeatMessage(arg: unknown): arg is HeartbeatMessage {
+    return HeartbeatMessage.safeParse(arg).success
+}
 
 export default function useOperatorLiveNodes(operatorId: string) {
     const streamId = `${operatorId}/operator/coordination`
-    const [liveNodes, setLiveNodes] = useState<Record<string, boolean>>({})
-    const [isLoading, setIsLoading] = useState(true)
+
+    const [liveNodes, setLiveNodes] = useState<Record<string, true>>({})
+
+    const [isLoading, setIsLoading] = useState(false)
 
     useSubscribe(
         { id: streamId },
         {
             onError: (e) => {
-                console.warn(e)
+                console.warn('Failed to count live nodes', e)
             },
             onMessage(msg) {
-                const data = msg.parsedContent as any
-                if (data?.msgType === 'heartbeat' && data?.peerDescriptor?.id != null) {
-                    const address = (data.peerDescriptor.id as string).toLowerCase()
-                    if (!liveNodes[address]) {
-                        setLiveNodes((prev) => ({...prev, [address]: true}))
-                    }
+                if (!isHeartbeatMessage(msg)) {
+                    return
                 }
+
+                const address = msg.parsedContent.peerDescriptor.id.toLowerCase()
+
+                setLiveNodes((prev) =>
+                    prev[address] ? prev : { ...prev, [address]: true },
+                )
             },
         },
     )
 
     useEffect(() => {
         let mounted = true
+
+        setIsLoading(true)
 
         setTimeout(() => {
             if (mounted) {

--- a/src/hooks/useOperatorLiveNodes.ts
+++ b/src/hooks/useOperatorLiveNodes.ts
@@ -3,7 +3,7 @@ import { useSubscribe } from 'streamr-client-react'
 
 export default function useOperatorLiveNodes(operatorId: string) {
     const streamId = `${operatorId}/operator/coordination`
-    const [liveNodes, setLiveNodes] = useState<string[]>([])
+    const [liveNodes, setLiveNodes] = useState<Record<string, boolean>>({})
     const [isLoading, setIsLoading] = useState(true)
 
     useSubscribe(
@@ -16,8 +16,8 @@ export default function useOperatorLiveNodes(operatorId: string) {
                 const data = msg.parsedContent as any
                 if (data?.msgType === 'heartbeat' && data?.peerDescriptor?.id != null) {
                     const address = (data.peerDescriptor.id as string).toLowerCase()
-                    if (!liveNodes.includes(address)) {
-                        setLiveNodes((prev) => [...prev, address])
+                    if (!liveNodes[address]) {
+                        setLiveNodes((prev) => ({...prev, [address]: true}))
                     }
                 }
             },
@@ -31,7 +31,7 @@ export default function useOperatorLiveNodes(operatorId: string) {
     }, [])
 
     return {
-        count: liveNodes?.length,
+        count: Object.keys(liveNodes).length,
         isLoading,
     }
 }


### PR DESCRIPTION
Previously, the same node id could be counted multiple times because of race conditions between checking `liveNodes.includes(address)` and updating `liveNodes`. Fix this by turning `liveNodes` into an object instead of an array, in which case the updates become idempotent.

Please feel free to take over this PR if you prefer a different approach!