### PR TITLE
FRONT-1580 added row hover effect in the ScrollTable

### DIFF
--- a/src/shared/components/ScrollTable/ScrollTable.styles.tsx
+++ b/src/shared/components/ScrollTable/ScrollTable.styles.tsx
@@ -93,6 +93,9 @@ export const ScrollTableCell = styled.div`
     &.action-cell {
         border-left: 1px solid ${COLORS.secondary};
     }
+    &.hover {
+        background-color: ${COLORS.secondaryLight};
+    }
 `
 
 export const FloatingLoadingIndicator = styled(LoadingIndicator)`

--- a/src/shared/components/ScrollTable/ScrollTable.tsx
+++ b/src/shared/components/ScrollTable/ScrollTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
     FloatingLoadingIndicator,
@@ -95,6 +95,7 @@ export const ScrollTableCore = <T extends object>({
 }: ScrollTableProps<T>) => {
     const stickyColumns = columns.filter((column) => column.isSticky)
     const nonStickyColumns = columns.filter((column) => !column.isSticky)
+    const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null)
     return (
         <ScrollTableCellsWrap
             stickyColumnCount={stickyColumns.length}
@@ -112,9 +113,15 @@ export const ScrollTableCore = <T extends object>({
                                     return (
                                         <ScrollTableCell
                                             key={id}
-                                            className={'align-' + stickyColumn.align}
+                                            className={
+                                                'align-' +
+                                                stickyColumn.align +
+                                                (hoveredRowIndex === id ? ' hover' : '')
+                                            }
                                             as={linkMapper ? Link : 'div'}
                                             to={linkMapper ? linkMapper(element) : ''}
+                                            onMouseEnter={() => setHoveredRowIndex(id)}
+                                            onMouseLeave={() => setHoveredRowIndex(null)}
                                         >
                                             {stickyColumn.valueMapper(element)}
                                         </ScrollTableCell>
@@ -143,7 +150,17 @@ export const ScrollTableCore = <T extends object>({
                                                 to={linkMapper ? linkMapper(element) : ''}
                                                 key={id}
                                                 className={
-                                                    'align-' + nonStickyColumn.align
+                                                    'align-' +
+                                                    nonStickyColumn.align +
+                                                    (hoveredRowIndex === id
+                                                        ? ' hover'
+                                                        : '')
+                                                }
+                                                onMouseEnter={() =>
+                                                    setHoveredRowIndex(id)
+                                                }
+                                                onMouseLeave={() =>
+                                                    setHoveredRowIndex(null)
                                                 }
                                             >
                                                 {nonStickyColumn.valueMapper(element)}
@@ -158,8 +175,16 @@ export const ScrollTableCore = <T extends object>({
                 {actions && actions.length && (
                     <ScrollTableColumn className="action-column">
                         <ScrollTableHeaderCell />
-                        {elements.map((element, index) => (
-                            <ScrollTableCell key={index} className="action-cell">
+                        {elements.map((element, id) => (
+                            <ScrollTableCell
+                                key={id}
+                                className={
+                                    'action-cell' +
+                                    (hoveredRowIndex === id ? ' hover' : '')
+                                }
+                                onMouseEnter={() => setHoveredRowIndex(id)}
+                                onMouseLeave={() => setHoveredRowIndex(null)}
+                            >
                                 <Popover
                                     title={'actions'}
                                     type={'verticalMeatball'}


### PR DESCRIPTION
Since the ScrollTable renders the table by columns, not by rows, as tables usually do I had to use onMouseEnter and onMouseLeave handlers to set which row should be highlighted