### PR TITLE
FRONT-1592: Operator nodes reachability

### DIFF
--- a/src/components/OperatorChecklist.tsx
+++ b/src/components/OperatorChecklist.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, ReactNode, useEffect, useState } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import CheckCircleIcon from '@atlaskit/icon/glyph/check-circle'
 import JiraFailedBuildStatusIcon from '@atlaskit/icon/glyph/jira/failed-build-status'
 import { defaultChainConfig } from '~/getters/getChainConfig'
@@ -14,7 +14,7 @@ import { Separator } from '~/components/Separator'
 import { TABLET } from '~/shared/utils/styled'
 import { StatCellLabelTip } from '~/components/StatGrid'
 import { useInterceptHeartbeats } from '~/hooks/useInterceptHeartbeats'
-import { SponsorshipPaymentTokenName } from './SponsorshipPaymentTokenName'
+import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 
 export function OperatorChecklist({ operatorId }: { operatorId: string | undefined }) {
     const { funded, nodesDeclared, nodesFunded, nodesReachable, nodesRunning } =
@@ -74,7 +74,6 @@ export function OperatorChecklist({ operatorId }: { operatorId: string | undefin
             </ChecklistItem>
             <Separator />
             <ChecklistItem
-                disabled
                 state={nodesReachable}
                 tip={<p>The websocket port on your nodes should be reachable.</p>}
             >
@@ -199,20 +198,18 @@ function useOperatorChecklist(operatorId: string | undefined): OperatorChecklist
 
 function ChecklistItem({
     children,
-    disabled = false,
     state,
     tip = '',
 }: {
     children: ReactNode
-    disabled?: boolean
     state?: boolean
     tip?: ReactNode
 }) {
     return (
-        <ChecklistItemRoot $disabled={disabled}>
+        <ChecklistItemRoot>
             <div>
                 {state === false && (
-                    <IconWrap $color={disabled ? void 0 : '#FF5C00'}>
+                    <IconWrap $color="#FF5C00">
                         <JiraFailedBuildStatusIcon label="Error" size="medium" />
                     </IconWrap>
                 )}
@@ -222,7 +219,7 @@ function ChecklistItem({
                     </IconWrap>
                 )}
                 {state === true && (
-                    <IconWrap $color={disabled ? void 0 : '#0EAC1B'}>
+                    <IconWrap $color="#0EAC1B">
                         <CheckCircleIcon label="Ok" size="medium" />
                     </IconWrap>
                 )}
@@ -248,7 +245,7 @@ function ChecklistItem({
     )
 }
 
-const ChecklistItemRoot = styled.div<{ $disabled: boolean }>`
+const ChecklistItemRoot = styled.div`
     align-items: center;
     display: grid;
     gap: 20px;
@@ -258,14 +255,6 @@ const ChecklistItemRoot = styled.div<{ $disabled: boolean }>`
     @media ${TABLET} {
         padding: 16px 40px;
     }
-
-    ${({ $disabled }) =>
-        $disabled &&
-        css`
-            > :not(:last-child) {
-                opacity: 0.3;
-            }
-        `}
 `
 
 function getQuestionMarkIconAttrs(): ComponentProps<typeof SvgIcon> {

--- a/src/components/OperatorChecklist.tsx
+++ b/src/components/OperatorChecklist.tsx
@@ -15,6 +15,7 @@ import { TABLET } from '~/shared/utils/styled'
 import { StatCellLabelTip } from '~/components/StatGrid'
 import { useInterceptHeartbeats } from '~/hooks/useInterceptHeartbeats'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
+import { useOperatorReachability } from '~/shared/stores/operatorReachability'
 
 export function OperatorChecklist({ operatorId }: { operatorId: string | undefined }) {
     const { funded, nodesDeclared, nodesFunded, nodesReachable, nodesRunning } =
@@ -98,13 +99,16 @@ function useOperatorChecklist(operatorId: string | undefined): OperatorChecklist
 
     const [nodesFunded, setNodesFunded] = useState<boolean>()
 
-    const [nodesReachable] = useState<boolean>(false)
-
     const heartbeats = useInterceptHeartbeats(operatorId)
 
     const { count, isLoading: isLoadingLiveNodes } = useOperatorLiveNodes(heartbeats)
 
     const nodesRunning = isLoadingLiveNodes ? undefined : count > 0
+
+    const reachability = useOperatorReachability(heartbeats)
+
+    const nodesReachable =
+        isLoadingLiveNodes || reachability === 'probing' ? void 0 : reachability === 'all'
 
     useEffect(() => {
         setNodesFunded(undefined)

--- a/src/shared/stores/operatorReachability.ts
+++ b/src/shared/stores/operatorReachability.ts
@@ -156,8 +156,6 @@ export function useOperatorReachability(
 
         if (reachable) {
             numOfReachableNodes += 1
-
-            continue
         }
     }
 

--- a/src/shared/stores/operatorReachability.ts
+++ b/src/shared/stores/operatorReachability.ts
@@ -60,7 +60,7 @@ const useOperatorReachabilityStore = create<{
 
             if (pending || updatedAt + TTL >= Date.now()) {
                 /**
-                 * Ignore cache hits and prending probes. Note that we probe based
+                 * Ignore cache hits and pending probes. Note that we probe based
                  * on WebSocket URLs not on node addresses. We support the unlikely
                  * but technically possible scenario where nodes share a URL.
                  */

--- a/src/shared/stores/operatorReachability.ts
+++ b/src/shared/stores/operatorReachability.ts
@@ -1,0 +1,169 @@
+import { produce } from 'immer'
+import { useEffect } from 'react'
+import { create } from 'zustand'
+import { Heartbeat } from '~/hooks/useInterceptHeartbeats'
+import { sleep } from '~/utils'
+
+const TTL = 60 * 1000
+
+interface Probe {
+    updatedAt: number
+    reachable: boolean
+    pending: boolean
+}
+
+const useOperatorReachabilityStore = create<{
+    probes: Record<string, Probe | undefined>
+    nodes: Record<string, string | undefined>
+    probe: (
+        nodeAddress: string,
+        heartbeat: Heartbeat,
+        options?: { timeoutMillis?: number },
+    ) => Promise<void>
+}>((set, get) => {
+    function updateProbe(url: string, fn: (probe: Probe) => Probe | void) {
+        set((store) =>
+            produce(store, ({ probes }) => {
+                const updatedAt = Date.now()
+
+                probes[url] = produce(
+                    Object.assign(probes[url] || { reachable: false, pending: false }, {
+                        updatedAt,
+                    }),
+                    fn,
+                )
+            }),
+        )
+    }
+
+    return {
+        nodes: {},
+
+        probes: {},
+
+        async probe(nodeAddress, heartbeat, { timeoutMillis = 10000 } = {}) {
+            const { host, port, tls = false } = heartbeat.websocket || {}
+
+            const url = host && port ? `${tls ? 'wss:' : 'ws:'}//${host}:${port}` : ''
+
+            set((store) =>
+                produce(store, (draft) => {
+                    /**
+                     * Heartbeats for a single node can carry different WebSocket URLs
+                     * over time, cause c'est la vie.
+                     */
+                    draft.nodes[nodeAddress] = url
+                }),
+            )
+
+            const { updatedAt = 0, pending = false } = get().probes[url] || {}
+
+            if (pending || updatedAt + TTL >= Date.now()) {
+                /**
+                 * Ignore cache hits and prending probes. Note that we probe based
+                 * on WebSocket URLs not on node addresses. We support the unlikely
+                 * but technically possible scenario where nodes share a URL.
+                 */
+                return
+            }
+
+            updateProbe(url, (draft) => {
+                draft.pending = true
+            })
+
+            let reachable = false
+
+            let ws: WebSocket | undefined
+
+            try {
+                reachable = await Promise.race([
+                    sleep(timeoutMillis).then(() => {
+                        throw new Error('Timeout')
+                    }),
+                    new Promise<boolean>((resolve, reject) => {
+                        if (!url) {
+                            return void resolve(false)
+                        }
+
+                        ws = new WebSocket(url)
+
+                        ws.addEventListener('open', () => {
+                            resolve(true)
+                        })
+
+                        ws.addEventListener('error', (e) => {
+                            reject(e)
+                        })
+                    }),
+                ])
+            } finally {
+                ws?.close()
+
+                ws = undefined
+
+                updateProbe(url, (draft) => {
+                    Object.assign(draft, {
+                        pending: false,
+                        reachable,
+                    })
+                })
+            }
+        },
+    }
+})
+
+type Reachability = 'probing' | 'none' | 'all' | 'some'
+
+export function useOperatorReachability(
+    heartbeats: Record<string, Heartbeat | undefined>,
+): Reachability {
+    const { probe, nodes, probes } = useOperatorReachabilityStore()
+
+    useEffect(() => {
+        Object.entries(heartbeats).forEach(([nodeAddress, heartbeat]) => {
+            if (!heartbeat) {
+                return
+            }
+
+            void (async () => {
+                try {
+                    await probe(nodeAddress, heartbeat)
+                } catch (e) {
+                    console.warn(
+                        `Failed to probe WebSocket URL for node "${nodeAddress}"`,
+                        heartbeat,
+                        e,
+                    )
+                }
+            })()
+        })
+    }, [heartbeats, probe])
+
+    const nodeAddresses = Object.keys(heartbeats)
+
+    let numOfReachableNodes = 0
+
+    for (const addr of nodeAddresses) {
+        const { reachable = false, pending = false } = probes[nodes[addr] || ''] || {}
+
+        if (pending) {
+            /**
+             * At least one node is being probbed and that's all we can tell
+             * about the collective.
+             */
+            return 'probing'
+        }
+
+        if (reachable) {
+            numOfReachableNodes += 1
+
+            continue
+        }
+    }
+
+    if (!numOfReachableNodes) {
+        return 'none'
+    }
+
+    return nodeAddresses.length === numOfReachableNodes ? 'all' : 'some'
+}


### PR DESCRIPTION
Give `useOperatorReachability` a collection of heartbeats to learn the condition of your fleet. It also caches per-URL probe for a minute, comes with timeout support, etc. It's pretty neat.