### PR TITLE
FRONT-1606: Hide "Network Explorer" link from the navigation

### DIFF
--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -62,14 +62,6 @@ const extendedNetworkNav: {
         subtitle: 'Explore Operators and delegate',
         link: routes.network.operators(),
     },
-    {
-        title: 'The Network Explorer',
-        subtitle:
-            'View and search for nodes, streams and connections, with live and historical metrics.',
-        link: routes.networkExplorer(),
-        rel: 'noopener',
-        target: '_blank',
-    },
 ]
 
 const networkLinks = [


### PR DESCRIPTION
I actually remove it completely. Once we need it again let's just bring it back from the dead, eh?