### PR TITLE
FRONT-1614: Add missing / fix invalid table columns

### DIFF
--- a/src/components/NetworkUtils.tsx
+++ b/src/components/NetworkUtils.tsx
@@ -50,6 +50,10 @@ export const StreamInfoCell = styled.div`
 
     .stream-description {
         font-size: 14px;
+        max-width: 208px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .stream-description:empty {

--- a/src/components/QueriedSponsorshipsTable.tsx
+++ b/src/components/QueriedSponsorshipsTable.tsx
@@ -5,8 +5,6 @@ import {
     ScrollTableCore,
     ScrollTableOrderDirection,
 } from '~/shared/components/ScrollTable/ScrollTable'
-import { truncateStreamName } from '~/shared/utils/text'
-import { StreamDescription } from '~/components/StreamDescription'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 import { abbreviateNumber } from '~/shared/utils/abbreviateNumber'
 import { useWalletAccount } from '~/shared/stores/wallet'
@@ -22,7 +20,7 @@ import {
     useSponsorshipTokenInfo,
 } from '~/hooks/sponsorships'
 import { isRejectionReason } from '~/modals/BaseModal'
-import { StreamInfoCell } from './NetworkUtils'
+import { FundedUntilCell, StreamIdCell } from '~/components/Table'
 
 interface Props {
     noDataFirstLine?: ReactNode
@@ -75,14 +73,7 @@ export function QueriedSponsorshipsTable({
                     {
                         displayName: 'Stream ID',
                         valueMapper: ({ streamId }) => (
-                            <StreamInfoCell>
-                                <span className="stream-id">
-                                    {truncateStreamName(streamId)}
-                                </span>
-                                <span className="stream-description">
-                                    <StreamDescription streamId={streamId} />
-                                </span>
-                            </StreamInfoCell>
+                            <StreamIdCell streamId={streamId} />
                         ),
                         align: 'start',
                         isSticky: true,
@@ -128,6 +119,17 @@ export function QueriedSponsorshipsTable({
                         isSticky: false,
                         key: 'apy',
                         sortable: true,
+                    },
+                    {
+                        displayName: 'Funded until',
+                        valueMapper: (element) => (
+                            <FundedUntilCell
+                                projectedInsolvencyAt={element.projectedInsolvencyAt}
+                            />
+                        ),
+                        align: 'start',
+                        isSticky: false,
+                        key: 'fundedUntil',
                     },
                 ]}
                 actions={[

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import styled from 'styled-components'
+import JiraFailedBuildStatusIcon from '@atlaskit/icon/glyph/jira/failed-build-status'
+import moment from 'moment'
+import { HubAvatar, HubImageAvatar } from '~/shared/components/AvatarImage'
+import { truncate, truncateStreamName } from '~/shared/utils/text'
+import { StreamInfoCell } from '~/components/NetworkUtils'
+import { StreamDescription } from '~/components/StreamDescription'
+import { Tip, TipIconWrap } from '~/components/Tip'
+
+/**
+ * Operator name and avatar formatter.
+ */
+export function OperatorIdCell({
+    operatorId,
+    imageUrl,
+    operatorName,
+}: {
+    operatorId: string
+    imageUrl?: string
+    operatorName?: string
+}) {
+    return (
+        <OperatorIdCellRoot>
+            {imageUrl ? (
+                <HubImageAvatar src={imageUrl} alt={imageUrl || operatorId} />
+            ) : (
+                <HubAvatar id={operatorId} />
+            )}
+            <span>{operatorName || truncate(operatorId)}</span>
+        </OperatorIdCellRoot>
+    )
+}
+
+const OperatorIdCellRoot = styled.div`
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+`
+
+/**
+ * Stream id and description formatter.
+ */
+export function StreamIdCell({ streamId }: { streamId: string }) {
+    return (
+        <StreamInfoCell>
+            <span className="stream-id">{truncateStreamName(streamId)}</span>
+            <span className="stream-description">
+                <StreamDescription streamId={streamId} />
+            </span>
+        </StreamInfoCell>
+    )
+}
+
+/**
+ * Sponsorship's projected insolvency timestamp formatter.
+ */
+export function FundedUntilCell({
+    projectedInsolvencyAt,
+}: {
+    projectedInsolvencyAt: number
+}) {
+    const value = moment(projectedInsolvencyAt * 1000)
+
+    return (
+        <FundedUntilCellRoot>
+            {value.format('YYYY-MM-DD')}
+            {value.isBefore(Date.now()) && (
+                <Tip
+                    handle={
+                        <TipIconWrap $color="#ff5c00">
+                            <JiraFailedBuildStatusIcon label="Error" />
+                        </TipIconWrap>
+                    }
+                >
+                    Sponsorship expired
+                </Tip>
+            )}
+        </FundedUntilCellRoot>
+    )
+}
+
+const FundedUntilCellRoot = styled.div`
+    align-items: center;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: auto auto;
+
+    ${TipIconWrap} svg {
+        width: 18px;
+        height: 18px;
+    }
+`

--- a/src/pages/NetworkOverviewPage.tsx
+++ b/src/pages/NetworkOverviewPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import moment from 'moment'
 import { useQuery } from '@tanstack/react-query'
@@ -14,13 +13,10 @@ import {
 } from '~/shared/components/TimeSeriesGraph/chartUtils'
 import { abbreviateNumber } from '~/shared/utils/abbreviateNumber'
 import NetworkChartDisplay from '~/components/NetworkChartDisplay'
-import { COLORS, MEDIUM } from '~/shared/utils/styled'
 import WalletPass from '~/components/WalletPass'
 import { NoData } from '~/shared/components/NoData'
 import routes from '~/routes'
 import { useWalletAccount } from '~/shared/stores/wallet'
-import { truncate } from '~/shared/utils/text'
-import { HubAvatar } from '~/shared/components/AvatarImage'
 import { ScrollTableCore } from '~/shared/components/ScrollTable/ScrollTable'
 import { fromAtto, fromDecimals } from '~/marketplace/utils/math'
 import {
@@ -45,6 +41,7 @@ import { LoadMoreButton } from '~/components/LoadMore'
 import { Separator } from '~/components/Separator'
 import { QueriedSponsorshipsTable } from '~/components/QueriedSponsorshipsTable'
 import { refetchQuery } from '~/utils'
+import { OperatorIdCell } from '~/components/Table'
 
 export function NetworkOverviewPage() {
     return (
@@ -257,10 +254,15 @@ function MyDelegations() {
                             columns={[
                                 {
                                     displayName: 'Operator ID',
-                                    valueMapper: ({ id }) => (
-                                        <OperatorCell>
-                                            <HubAvatar id={id} /> {truncate(id)}
-                                        </OperatorCell>
+                                    valueMapper: ({
+                                        id,
+                                        metadata: { imageUrl, name },
+                                    }) => (
+                                        <OperatorIdCell
+                                            operatorId={id}
+                                            imageUrl={imageUrl}
+                                            operatorName={name}
+                                        />
                                     ),
                                     align: 'start',
                                     isSticky: true,
@@ -338,14 +340,6 @@ function MyDelegations() {
         </NetworkPageSegment>
     )
 }
-
-const OperatorCell = styled.div`
-    align-items: center;
-    color: ${COLORS.primary};
-    display: flex;
-    font-weight: ${MEDIUM};
-    gap: 5px;
-`
 
 function MySponsorships() {
     const wallet = useWalletAccount()

--- a/src/pages/OperatorsPage.tsx
+++ b/src/pages/OperatorsPage.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import { toaster } from 'toasterhea'
 import { UseInfiniteQueryResult } from '@tanstack/react-query'
@@ -16,8 +15,6 @@ import { useWalletAccount } from '~/shared/stores/wallet'
 import { fromAtto } from '~/marketplace/utils/math'
 import { createOperator } from '~/services/operators'
 import BecomeOperatorModal from '~/modals/BecomeOperatorModal'
-import { truncate } from '~/shared/utils/text'
-import { HubAvatar, HubImageAvatar } from '~/shared/components/AvatarImage'
 import { waitForGraphSync } from '~/getters/waitForGraphSync'
 import routes from '~/routes'
 import { NetworkActionBar } from '~/components/ActionBars/NetworkActionBar'
@@ -35,6 +32,7 @@ import { refetchQuery } from '~/utils'
 import { abbreviateNumber } from '~/shared/utils/abbreviateNumber'
 import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { useTableOrder } from '~/hooks/useTableOrder'
+import { OperatorIdCell } from '~/components/Table'
 
 const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)
 
@@ -187,13 +185,6 @@ export const OperatorsPage = () => {
     )
 }
 
-const OperatorNameCell = styled.div`
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-    align-items: center;
-`
-
 function DelegationsTable({
     query,
     tokenSymbol,
@@ -210,18 +201,12 @@ function DelegationsTable({
             columns={[
                 {
                     displayName: 'Operator Name',
-                    valueMapper: (element) => (
-                        <OperatorNameCell>
-                            {element.metadata?.imageUrl ? (
-                                <HubImageAvatar
-                                    src={element.metadata.imageUrl}
-                                    alt={element.metadata.imageUrl || element.id}
-                                />
-                            ) : (
-                                <HubAvatar id={element.id} />
-                            )}
-                            <span>{element.metadata?.name || truncate(element.id)}</span>
-                        </OperatorNameCell>
+                    valueMapper: ({ id, metadata: { name, imageUrl } }) => (
+                        <OperatorIdCell
+                            operatorId={id}
+                            operatorName={name}
+                            imageUrl={imageUrl}
+                        />
                     ),
                     align: 'start',
                     isSticky: true,
@@ -300,18 +285,12 @@ function OperatorsTable({
             columns={[
                 {
                     displayName: 'Operator Name',
-                    valueMapper: (element) => (
-                        <OperatorNameCell>
-                            {element.metadata?.imageUrl ? (
-                                <HubImageAvatar
-                                    src={element.metadata.imageUrl}
-                                    alt={element.metadata.imageUrl || element.id}
-                                />
-                            ) : (
-                                <HubAvatar id={element.id} />
-                            )}
-                            <span>{element.metadata?.name || truncate(element.id)}</span>
-                        </OperatorNameCell>
+                    valueMapper: ({ id, metadata: { name, imageUrl } }) => (
+                        <OperatorIdCell
+                            operatorId={id}
+                            operatorName={name}
+                            imageUrl={imageUrl}
+                        />
                     ),
                     align: 'start',
                     isSticky: true,

--- a/src/pages/SingleOperatorPage.tsx
+++ b/src/pages/SingleOperatorPage.tsx
@@ -4,7 +4,6 @@ import { toaster } from 'toasterhea'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import moment from 'moment'
-import JiraFailedBuildStatusIcon from '@atlaskit/icon/glyph/jira/failed-build-status'
 import { NetworkHelmet } from '~/components/Helmet'
 import Layout, { LayoutColumn } from '~/components/Layout'
 import { NoData } from '~/shared/components/NoData'
@@ -57,7 +56,7 @@ import {
 } from '~/shared/stores/uncollectedEarnings'
 import { confirm } from '~/getters/confirm'
 import { truncate } from '~/shared/utils/text'
-import { Tip, TipIconWrap } from '~/components/Tip'
+import { FundedUntilCell, StreamIdCell } from '~/components/Table'
 
 const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)
 
@@ -320,7 +319,9 @@ export const SingleOperatorPage = () => {
                                 columns={[
                                     {
                                         displayName: 'Stream ID',
-                                        valueMapper: (element) => element.streamId,
+                                        valueMapper: ({ streamId }) => (
+                                            <StreamIdCell streamId={streamId} />
+                                        ),
                                         align: 'start',
                                         isSticky: true,
                                         key: 'streamId',
@@ -347,28 +348,13 @@ export const SingleOperatorPage = () => {
                                     },
                                     {
                                         displayName: 'Funded until',
-                                        valueMapper: (element) => {
-                                            const fundedUntil = moment(
-                                                element.projectedInsolvencyAt * 1000,
-                                            )
-
-                                            return (
-                                                <FundedUntil>
-                                                    {fundedUntil.format('YYYY-MM-DD')}
-                                                    {fundedUntil.isBefore(Date.now()) && (
-                                                        <Tip
-                                                            handle={
-                                                                <TipIconWrap $color="#ff5c00">
-                                                                    <JiraFailedBuildStatusIcon label="Error" />
-                                                                </TipIconWrap>
-                                                            }
-                                                        >
-                                                            Sponsorship expired
-                                                        </Tip>
-                                                    )}
-                                                </FundedUntil>
-                                            )
-                                        },
+                                        valueMapper: (element) => (
+                                            <FundedUntilCell
+                                                projectedInsolvencyAt={
+                                                    element.projectedInsolvencyAt
+                                                }
+                                            />
+                                        ),
                                         align: 'start',
                                         isSticky: false,
                                         key: 'fundedUntil',
@@ -687,15 +673,3 @@ function UncollectedEarnings({
         <Spinner color="blue" />
     )
 }
-
-const FundedUntil = styled.div`
-    align-items: center;
-    display: grid;
-    gap: 8px;
-    grid-template-columns: auto auto;
-
-    ${TipIconWrap} svg {
-        width: 18px;
-        height: 18px;
-    }
-`

--- a/src/pages/SingleSponsorshipPage.tsx
+++ b/src/pages/SingleSponsorshipPage.tsx
@@ -7,7 +7,6 @@ import Layout, { LayoutColumn } from '~/components/Layout'
 import { NoData } from '~/shared/components/NoData'
 import LoadingIndicator from '~/shared/components/LoadingIndicator'
 import { LAPTOP } from '~/shared/utils/styled'
-import { HubAvatar, HubImageAvatar } from '~/shared/components/AvatarImage'
 import { truncate } from '~/shared/utils/text'
 import {
     formatLongDate,
@@ -26,6 +25,7 @@ import { ChartPeriodTabs } from '~/components/ChartPeriodTabs'
 import Tabs, { Tab } from '~/shared/components/Tabs'
 import { NetworkChart } from '~/shared/components/TimeSeriesGraph'
 import { useSponsorshipQuery, useSponsorshipTokenInfo } from '~/hooks/sponsorships'
+import { OperatorIdCell } from '~/components/Table'
 
 export const SingleSponsorshipPage = () => {
     const sponsorshipId = useParams().id || ''
@@ -214,21 +214,11 @@ export const SingleSponsorshipPage = () => {
                                                     operatorId,
                                                     metadata: { imageUrl, name },
                                                 }) => (
-                                                    <OperatorCell>
-                                                        {imageUrl ? (
-                                                            <HubImageAvatar
-                                                                src={imageUrl}
-                                                                alt={
-                                                                    imageUrl || operatorId
-                                                                }
-                                                            />
-                                                        ) : (
-                                                            <HubAvatar id={operatorId} />
-                                                        )}
-                                                        <span>
-                                                            {name || truncate(operatorId)}
-                                                        </span>
-                                                    </OperatorCell>
+                                                    <OperatorIdCell
+                                                        operatorId={operatorId}
+                                                        imageUrl={imageUrl}
+                                                        operatorName={name}
+                                                    />
                                                 ),
                                                 align: 'start',
                                             },
@@ -302,11 +292,4 @@ const ChartGrid = styled(SegmentGrid)`
     @media ${LAPTOP} {
         grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     }
-`
-
-const OperatorCell = styled.div`
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    gap: 12px;
 `


### PR DESCRIPTION
In short,
- I add "Funded until" to all Sponsorship tables,
- I fix and unify all Operator Id cells (avatar + name), and
- I unify all Stream id cells for Sponsorships – they all, asynchronously fetch stream descriptions now, too!

Addresses the following tickets
- FRONT-1614
- FRONT-1611
- FRONT-1610