### PR TITLE
FRONT-1624: Fix Network accordion item clicks

### DIFF
--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -283,7 +283,7 @@ const UnstyledMobileNav: FunctionComponent<{ className?: string }> = ({ classNam
                 </NavbarLinkMobile>
                 <NavbarLinkMobile highlight={isNetworkTabActive(pathname)}>
                     {isFeatureEnabled(FeatureFlag.PhaseTwo) ? (
-                        <NavLink onClick={(event) => event.stopPropagation()} as={'div'}>
+                        <NavLink as="div">
                             <Accordion
                                 flush
                                 open={accordionOpen}


### PR DESCRIPTION
Click on Network accordion items should dismiss the whole nav overlay. Here's the fix.