### PR TITLE
FRONT-1630: Link to the stream on sponsorship page

### DIFF
--- a/src/components/ActionBars/AboutEntity.tsx
+++ b/src/components/ActionBars/AboutEntity.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components'
+import { COLORS } from '~/shared/utils/styled'
+
+export const Address = styled.p`
+    align-items: center;
+    color: ${COLORS.primaryLight};
+    display: grid;
+    gap: 4px;
+    grid-template-columns: max-content max-content;
+
+    strong {
+        color: ${COLORS.primary};
+    }
+
+    svg {
+        display: block;
+    }
+`
+
+export const Banner = styled.div`
+    background: ${COLORS.secondaryLight};
+    border-radius: 6px;
+    padding: 12px;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 24px 1fr;
+    margin-top: 20px;
+
+    span[role='img'] {
+        color: ${COLORS.primaryDisabled};
+    }
+
+    svg,
+    span[role='img'] {
+        display: block;
+        width: 20px;
+        height: 20px;
+    }
+`
+
+export const IconWrap = styled.div`
+    align-items: center;
+    display: flex;
+    height: 24px;
+    justify-content: center;
+    width: 24px;
+`

--- a/src/components/ActionBars/AboutOperator.tsx
+++ b/src/components/ActionBars/AboutOperator.tsx
@@ -1,23 +1,20 @@
 import React from 'react'
-import styled from 'styled-components'
 import InfoIcon from '@atlaskit/icon/glyph/info'
 import { ParsedOperator } from '~/parsers/OperatorParser'
-import { COLORS } from '~/shared/utils/styled'
+import { DefaultSimpleDropdownMenu } from '~/components/SimpleDropdown'
+import { Address, Banner, IconWrap } from '~/components/ActionBars/AboutEntity'
 import { truncate } from '~/shared/utils/text'
-import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 import useCopy from '~/shared/hooks/useCopy'
 import { CopyIcon } from '~/icons'
-import { IconButton } from './IconButton'
-import { DefaultSimpleDropdownMenu } from './SimpleDropdown'
+import { IconButton } from '~/components/IconButton'
+import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 
-export function AboutOperator({
-    operator: {
+export function AboutOperator({ operator }: { operator: ParsedOperator }) {
+    const {
         owner,
         metadata: { description },
-    },
-}: {
-    operator: ParsedOperator
-}) {
+    } = operator
+
     const { copy } = useCopy()
 
     return (
@@ -59,48 +56,3 @@ export function AboutOperator({
         </DefaultSimpleDropdownMenu>
     )
 }
-
-const Address = styled.p`
-    align-items: center;
-    color: ${COLORS.primaryLight};
-    display: grid;
-    gap: 4px;
-    grid-template-columns: max-content auto;
-
-    strong {
-        color: ${COLORS.primary};
-    }
-
-    svg {
-        display: block;
-    }
-`
-
-const Banner = styled.div`
-    background: ${COLORS.secondaryLight};
-    border-radius: 6px;
-    padding: 12px;
-    display: grid;
-    gap: 10px;
-    grid-template-columns: 24px 1fr;
-    margin-top: 20px;
-
-    span[role='img'] {
-        color: ${COLORS.primaryDisabled};
-    }
-
-    svg,
-    span[role='img'] {
-        display: block;
-        width: 20px;
-        height: 20px;
-    }
-`
-
-const IconWrap = styled.div`
-    align-items: center;
-    display: flex;
-    height: 24px;
-    justify-content: center;
-    width: 24px;
-`

--- a/src/components/ActionBars/AboutSponsorship.tsx
+++ b/src/components/ActionBars/AboutSponsorship.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import InfoIcon from '@atlaskit/icon/glyph/info'
+import styled from 'styled-components'
+import { Link as PrestyledLink } from 'react-router-dom'
+import { ParsedSponsorship } from '~/parsers/SponsorshipParser'
+import { DefaultSimpleDropdownMenu } from '~/components/SimpleDropdown'
+import { Address, Banner, IconWrap } from '~/components/ActionBars/AboutEntity'
+import { truncateStreamName } from '~/shared/utils/text'
+import { ExternalLinkIcon } from '~/icons'
+import routes from '~/routes'
+
+export function AboutSponsorship({ sponsorship }: { sponsorship: ParsedSponsorship }) {
+    const { streamId } = sponsorship
+
+    return (
+        <DefaultSimpleDropdownMenu>
+            <Address>
+                <div>
+                    Sponsored stream: <strong>{truncateStreamName(streamId)}</strong>
+                </div>
+                <div>
+                    <Link to={routes.streams.show({ id: streamId })} target="_blank">
+                        <ExternalLinkIcon />
+                    </Link>
+                </div>
+            </Address>
+            <Banner>
+                <IconWrap>
+                    <InfoIcon label="Info" />
+                </IconWrap>
+                <div>
+                    <p>
+                        Sponsorships pay out tokens to staked operators for doing work
+                        in&nbsp;the network, i.e. relaying data in the associated stream.
+                        Sponsorships can be funded by anyone.
+                    </p>
+                    <p>
+                        <a
+                            href="https://docs.streamr.network/streamr-network/network-incentives"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                        >
+                            Learn more
+                        </a>
+                    </p>
+                </div>
+            </Banner>
+        </DefaultSimpleDropdownMenu>
+    )
+}
+
+const Link = styled(PrestyledLink)`
+    display: block;
+
+    :active {
+        transform: translateY(1px);
+    }
+`

--- a/src/components/ActionBars/OperatorActionBar.tsx
+++ b/src/components/ActionBars/OperatorActionBar.tsx
@@ -38,7 +38,6 @@ import { isRejectionReason } from '~/modals/BaseModal'
 import { abbreviateNumber } from '~/shared/utils/abbreviateNumber'
 import { useInterceptHeartbeats } from '~/hooks/useInterceptHeartbeats'
 import { Tip, TipIconWrap } from '~/components/Tip'
-import { AboutOperator } from '~/components/AboutOperator'
 import { getOperatorDelegationAmount } from '~/services/operators'
 import { PencilIcon } from '~/icons'
 import { goBack } from '~/utils'
@@ -47,7 +46,8 @@ import {
     ActionBarButtonCaret,
     ActionBarButtonInnerBody,
     ActionBarWalletDisplay,
-} from './ActionBarButton'
+} from '~/components/ActionBars/ActionBarButton'
+import { AboutOperator } from '~/components/ActionBars/AboutOperator'
 
 export const OperatorActionBar: FunctionComponent<{
     operator: ParsedOperator
@@ -101,6 +101,8 @@ export const OperatorActionBar: FunctionComponent<{
         },
     })
 
+    const { metadata } = operator
+
     return (
         <SingleElementPageActionBar>
             <SingleElementPageActionBarContainer>
@@ -120,15 +122,15 @@ export const OperatorActionBar: FunctionComponent<{
                                 <NetworkActionBarBackButtonIcon name="backArrow" />
                             </NetworkActionBarBackLink>
                             <NetworkActionBarTitle>
-                                {operator.metadata?.imageUrl ? (
+                                {metadata.imageUrl ? (
                                     <HubImageAvatar
-                                        src={operator.metadata.imageUrl}
-                                        alt={operator.metadata.name || operator.id}
+                                        src={metadata.imageUrl}
+                                        alt={metadata.name || operator.id}
                                     />
                                 ) : (
                                     <HubAvatar id={operator.id} />
                                 )}
-                                <span>{operator.metadata?.name || operator.id}</span>
+                                <span>{metadata.name || operator.id}</span>
                             </NetworkActionBarTitle>
                         </NetworkActionBarBackButtonAndTitle>
                         <NetworkActionBarInfoButtons>

--- a/src/components/ActionBars/SponsorshipActionBar.tsx
+++ b/src/components/ActionBars/SponsorshipActionBar.tsx
@@ -5,7 +5,7 @@ import { abbreviateNumber } from '~/shared/utils/abbreviateNumber'
 import Button from '~/shared/components/Button'
 import SvgIcon from '~/shared/components/SvgIcon'
 import routes from '~/routes'
-import { DefaultSimpleDropdownMenu, SimpleDropdown } from '~/components/SimpleDropdown'
+import { SimpleDropdown } from '~/components/SimpleDropdown'
 import { waitForGraphSync } from '~/getters/waitForGraphSync'
 import { Separator } from '~/components/Separator'
 import StatGrid, { StatCell } from '~/components/StatGrid'
@@ -44,7 +44,8 @@ import {
     ActionBarButtonCaret,
     ActionBarButtonInnerBody,
     ActionBarWalletDisplay,
-} from './ActionBarButton'
+} from '~/components/ActionBars/ActionBarButton'
+import { AboutSponsorship } from '~/components/ActionBars/AboutSponsorship'
 
 export function SponsorshipActionBar({
     sponsorship,
@@ -117,25 +118,7 @@ export function SponsorshipActionBar({
                                 <strong>{active ? 'Active' : 'Inactive'}</strong>
                             </ActionBarButtonBody>
                             <SimpleDropdown
-                                menu={
-                                    <DefaultSimpleDropdownMenu>
-                                        <p>
-                                            Sponsorships pay out tokens to staked
-                                            operators for doing work in&nbsp;the network,
-                                            i.e. relaying data in the associated stream.
-                                            Sponsorships can be funded by anyone.
-                                        </p>
-                                        <p>
-                                            <a
-                                                href="https://docs.streamr.network/streamr-network/network-incentives"
-                                                target="_blank"
-                                                rel="noreferrer noopener"
-                                            >
-                                                Learn more
-                                            </a>
-                                        </p>
-                                    </DefaultSimpleDropdownMenu>
-                                }
+                                menu={<AboutSponsorship sponsorship={sponsorship} />}
                             >
                                 {(toggle, isOpen) => (
                                     <ActionBarButton
@@ -144,7 +127,7 @@ export function SponsorshipActionBar({
                                     >
                                         <ActionBarButtonInnerBody>
                                             <SvgIcon name="page" />
-                                            <strong>About Sponsorships</strong>
+                                            <strong>About Sponsorship</strong>
                                         </ActionBarButtonInnerBody>
                                         <ActionBarButtonCaret $invert={isOpen} />
                                     </ActionBarButton>


### PR DESCRIPTION
It's mostly about making "About Sponsorship" and "About Operator" boxes look alike. Plus, there's the stream link.

Previous

![Screenshot 2023-10-26 at 3 58 18 PM](https://github.com/streamr-dev/core-frontend/assets/320066/de3a3cb3-b635-4ecc-bf7a-f4e0851daac5)

New

![Screenshot 2023-10-26 at 3 57 49 PM](https://github.com/streamr-dev/core-frontend/assets/320066/2226d9c0-ca4a-49d7-987e-0433acc82172)

And for reference, About Operator box

![Screenshot 2023-10-26 at 3 58 57 PM](https://github.com/streamr-dev/core-frontend/assets/320066/d2c4580b-80c2-4eed-9b0c-437c823ddf1e)
