### PR TITLE
FRONT-1635: Sponsorships of deleted streams

### DIFF
--- a/src/components/ActionBars/AboutEntity.tsx
+++ b/src/components/ActionBars/AboutEntity.tsx
@@ -24,7 +24,10 @@ export const Banner = styled.div`
     display: grid;
     gap: 10px;
     grid-template-columns: 24px 1fr;
-    margin-top: 20px;
+
+    * + & {
+        margin-top: 20px;
+    }
 
     span[role='img'] {
         color: ${COLORS.primaryDisabled};

--- a/src/components/ActionBars/AboutSponsorship.tsx
+++ b/src/components/ActionBars/AboutSponsorship.tsx
@@ -15,16 +15,18 @@ export function AboutSponsorship({ sponsorship }: { sponsorship: ParsedSponsorsh
 
     return (
         <DefaultSimpleDropdownMenu>
-            <Address>
-                <div>
-                    Sponsored stream: <strong>{truncateStreamName(streamId)}</strong>
-                </div>
-                <div>
-                    <Link to={routes.streams.show({ id: streamId })} target="_blank">
-                        <ExternalLinkIcon />
-                    </Link>
-                </div>
-            </Address>
+            {streamId && (
+                <Address>
+                    <div>
+                        Sponsored stream: <strong>{truncateStreamName(streamId)}</strong>
+                    </div>
+                    <div>
+                        <Link to={routes.streams.show({ id: streamId })} target="_blank">
+                            <ExternalLinkIcon />
+                        </Link>
+                    </div>
+                </Address>
+            )}
             <Banner>
                 <IconWrap>
                     <InfoIcon label="Info" />

--- a/src/components/ActionBars/SponsorshipActionBar.tsx
+++ b/src/components/ActionBars/SponsorshipActionBar.tsx
@@ -184,7 +184,7 @@ export function SponsorshipActionBar({
                         </Button>
                         {canEditStake ? (
                             <Button
-                                disabled={!operator || !streamId}
+                                disabled={!operator}
                                 waiting={isEditingSponsorshipFunding}
                                 onClick={async () => {
                                     if (!operator) {

--- a/src/components/ActionBars/SponsorshipActionBar.tsx
+++ b/src/components/ActionBars/SponsorshipActionBar.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, useMemo } from 'react'
 import styled from 'styled-components'
 import moment from 'moment'
-import { truncateStreamName } from '~/shared/utils/text'
+import { truncate, truncateStreamName } from '~/shared/utils/text'
 import { abbreviateNumber } from '~/shared/utils/abbreviateNumber'
 import Button from '~/shared/components/Button'
 import SvgIcon from '~/shared/components/SvgIcon'
@@ -89,6 +89,8 @@ export function SponsorshipActionBar({
 
     const maxOperatorsReached = sponsorship.operatorCount >= sponsorship.maxOperators
 
+    const { streamId } = sponsorship
+
     return (
         <SingleElementPageActionBar>
             <SingleElementPageActionBarContainer>
@@ -108,7 +110,11 @@ export function SponsorshipActionBar({
                                 <NetworkActionBarBackButtonIcon name="backArrow" />
                             </NetworkActionBarBackLink>
                             <NetworkActionBarTitle>
-                                {truncateStreamName(sponsorship.streamId, 30)}
+                                {streamId ? (
+                                    truncateStreamName(streamId, 30)
+                                ) : (
+                                    <>Sponsorship {truncate(sponsorship.id)}</>
+                                )}
                             </NetworkActionBarTitle>
                         </NetworkActionBarBackButtonAndTitle>
                         <NetworkActionBarInfoButtons>
@@ -149,6 +155,7 @@ export function SponsorshipActionBar({
                     </div>
                     <NetworkActionBarCTAs>
                         <Button
+                            disabled={!streamId}
                             waiting={isFundingSponsorship}
                             onClick={async () => {
                                 if (!wallet) {
@@ -177,7 +184,7 @@ export function SponsorshipActionBar({
                         </Button>
                         {canEditStake ? (
                             <Button
-                                disabled={!operator}
+                                disabled={!operator || !streamId}
                                 waiting={isEditingSponsorshipFunding}
                                 onClick={async () => {
                                     if (!operator) {
@@ -206,7 +213,7 @@ export function SponsorshipActionBar({
                             </Button>
                         ) : (
                             <Button
-                                disabled={!operator || maxOperatorsReached}
+                                disabled={!operator || maxOperatorsReached || !streamId}
                                 waiting={isJoiningSponsorshipAsOperator}
                                 onClick={async () => {
                                     if (!operator) {

--- a/src/components/QueriedSponsorshipsTable.tsx
+++ b/src/components/QueriedSponsorshipsTable.tsx
@@ -136,7 +136,7 @@ export function QueriedSponsorshipsTable({
                 actions={[
                     {
                         displayName: 'Sponsor',
-                        disabled: !wallet,
+                        disabled: ({ streamId }) => !streamId || !wallet,
                         async callback(element) {
                             if (!wallet) {
                                 return
@@ -194,7 +194,8 @@ export function QueriedSponsorshipsTable({
 
                         return {
                             displayName: 'Join as Operator',
-                            disabled: !operator || maxOperatorsReached,
+                            disabled:
+                                !element.streamId || !operator || maxOperatorsReached,
                             async callback() {
                                 if (!operator) {
                                     return

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -40,9 +40,24 @@ const OperatorIdCellRoot = styled.div`
 `
 
 /**
+ * Deleted stream id formatter.
+ */
+function DeletedStreamIdCell() {
+    return (
+        <StreamInfoCell>
+            <em className="stream-id">(deleted stream)</em>
+        </StreamInfoCell>
+    )
+}
+
+/**
  * Stream id and description formatter.
  */
-export function StreamIdCell({ streamId }: { streamId: string }) {
+export function StreamIdCell({ streamId = '' }: { streamId?: string }) {
+    if (!streamId) {
+        return <DeletedStreamIdCell />
+    }
+
     return (
         <StreamInfoCell>
             <span className="stream-id">{truncateStreamName(streamId)}</span>

--- a/src/parsers/OperatorParser.ts
+++ b/src/parsers/OperatorParser.ts
@@ -81,9 +81,12 @@ export const OperatorParser = z
                         minimumStakingPeriodSeconds: z.coerce.number(),
                         spotAPY: z.string().transform(toBN),
                         projectedInsolvency: z.coerce.number(),
-                        stream: z.object({
-                            id: z.string(),
-                        }),
+                        stream: z.union([
+                            z.object({
+                                id: z.string(),
+                            }),
+                            z.null(),
+                        ]),
                     }),
                 })
                 .transform(
@@ -95,7 +98,7 @@ export const OperatorParser = z
                             minimumStakingPeriodSeconds,
                             projectedInsolvency: projectedInsolvencyAt,
                             spotAPY,
-                            stream: { id: streamId },
+                            stream,
                         },
                         ...rest
                     }) => ({
@@ -106,7 +109,7 @@ export const OperatorParser = z
                         operatorId,
                         projectedInsolvencyAt,
                         spotAPY,
-                        streamId,
+                        streamId: stream?.id,
                     }),
                 ),
         ),

--- a/src/parsers/SponsorshipParser.ts
+++ b/src/parsers/SponsorshipParser.ts
@@ -18,9 +18,12 @@ export const SponsorshipParser = z
         operatorCount: z.number(),
         projectedInsolvency: z.coerce.number(),
         spotAPY: z.string().transform(fromAtto),
-        stream: z.object({
-            id: z.string(),
-        }),
+        stream: z.union([
+            z.object({
+                id: z.string(),
+            }),
+            z.null(),
+        ]),
         stakes: z.array(
             z
                 .object({
@@ -52,7 +55,7 @@ export const SponsorshipParser = z
             projectedInsolvency: projectedInsolvencyAt,
             spotAPY,
             stakes,
-            stream: { id: streamId },
+            stream,
             totalPayoutWeiPerSec,
             totalStakedWei,
             ...rest
@@ -76,7 +79,7 @@ export const SponsorshipParser = z
                     ...stake,
                     amount: fromDecimals(amountWei, decimals),
                 })),
-                streamId,
+                streamId: stream?.id,
                 totalStake: fromDecimals(totalStakedWei, decimals),
             }
         },


### PR DESCRIPTION
Notes
- I make parsers for sponsorships and operators support no-stream edge case and display improvised UIs in all places I could think of.
- I disable UIs for joining orphanized sponsorships as an operator, and for sponsoring it. Users can still edit their stake.