### PR TITLE
FRONT-1638: Bring back the nodes reachable check (light version)

### DIFF
--- a/src/components/OperatorChecklist.tsx
+++ b/src/components/OperatorChecklist.tsx
@@ -18,7 +18,7 @@ import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentToke
 import { useOperatorReachability } from '~/shared/stores/operatorReachability'
 
 export function OperatorChecklist({ operatorId }: { operatorId: string | undefined }) {
-    const { funded, nodesDeclared, nodesFunded, nodesRunning } =
+    const { funded, nodesDeclared, nodesFunded, nodesReachable, nodesRunning } =
         useOperatorChecklist(operatorId)
 
     return (
@@ -75,6 +75,23 @@ export function OperatorChecklist({ operatorId }: { operatorId: string | undefin
                 }
             >
                 Nodes running
+            </ChecklistItem>
+            <Separator />
+            <ChecklistItem
+                state={nodesReachable}
+                tip={
+                    <>
+                        <p>
+                            The Operator must ensure that their nodes can be reached
+                            on their node&apos;s configured WebSocket port.
+                        </p>
+                        <p>
+                            The default port is 32200.
+                        </p>
+                    </>
+                }
+            >
+                Nodes reachable
             </ChecklistItem>
         </>
     )

--- a/src/hooks/useInterceptHeartbeats.ts
+++ b/src/hooks/useInterceptHeartbeats.ts
@@ -25,11 +25,11 @@ export function useInterceptHeartbeats(operatorId: string | undefined) {
                     return
                 }
 
-                const address = msg.parsedContent.peerDescriptor.id.toLowerCase()
+                const { peerDescriptor } = msg.parsedContent
 
                 setHeartbeats((prev) => ({
                     ...prev,
-                    [address]: msg.parsedContent.peerDescriptor,
+                    [peerDescriptor.id]: peerDescriptor,
                 }))
             },
         },

--- a/src/shared/stores/operatorReachability.ts
+++ b/src/shared/stores/operatorReachability.ts
@@ -16,7 +16,7 @@ const useOperatorReachabilityStore = create<{
     probes: Record<string, Probe | undefined>
     nodes: Record<string, string | undefined>
     probe: (
-        nodeAddress: string,
+        nodeId: string,
         heartbeat: Heartbeat,
         options?: { timeoutMillis?: number },
     ) => Promise<void>
@@ -41,7 +41,7 @@ const useOperatorReachabilityStore = create<{
 
         probes: {},
 
-        async probe(nodeAddress, heartbeat, { timeoutMillis = 10000 } = {}) {
+        async probe(nodeId, heartbeat, { timeoutMillis = 10000 } = {}) {
             const { host, port, tls = false } = heartbeat.websocket || {}
 
             const url = host && port ? `${tls ? 'wss:' : 'ws:'}//${host}:${port}` : ''
@@ -52,7 +52,7 @@ const useOperatorReachabilityStore = create<{
                      * Heartbeats for a single node can carry different WebSocket URLs
                      * over time, cause c'est la vie.
                      */
-                    draft.nodes[nodeAddress] = url
+                    draft.nodes[nodeId] = url
                 }),
             )
 
@@ -120,17 +120,17 @@ export function useOperatorReachability(
     const { probe, nodes, probes } = useOperatorReachabilityStore()
 
     useEffect(() => {
-        Object.entries(heartbeats).forEach(([nodeAddress, heartbeat]) => {
+        Object.entries(heartbeats).forEach(([nodeId, heartbeat]) => {
             if (!heartbeat) {
                 return
             }
 
             void (async () => {
                 try {
-                    await probe(nodeAddress, heartbeat)
+                    await probe(nodeId, heartbeat)
                 } catch (e) {
                     console.warn(
-                        `Failed to probe WebSocket URL for node "${nodeAddress}"`,
+                        `Failed to probe WebSocket URL for node "${nodeId}"`,
                         heartbeat,
                         e,
                     )
@@ -139,12 +139,12 @@ export function useOperatorReachability(
         })
     }, [heartbeats, probe])
 
-    const nodeAddresses = Object.keys(heartbeats)
+    const nodeIds = Object.keys(heartbeats)
 
     let numOfReachableNodes = 0
 
-    for (const addr of nodeAddresses) {
-        const { reachable = false, pending = false } = probes[nodes[addr] || ''] || {}
+    for (const nodeId of nodeIds) {
+        const { reachable = false, pending = false } = probes[nodes[nodeId] || ''] || {}
 
         if (pending) {
             /**
@@ -163,5 +163,5 @@ export function useOperatorReachability(
         return 'none'
     }
 
-    return nodeAddresses.length === numOfReachableNodes ? 'all' : 'some'
+    return nodeIds.length === numOfReachableNodes ? 'all' : 'some'
 }

--- a/src/shared/stores/operatorReachability.ts
+++ b/src/shared/stores/operatorReachability.ts
@@ -80,21 +80,7 @@ const useOperatorReachabilityStore = create<{
                     sleep(timeoutMillis).then(() => {
                         throw new Error('Timeout')
                     }),
-                    new Promise<boolean>((resolve, reject) => {
-                        if (!url) {
-                            return void resolve(false)
-                        }
-
-                        ws = new WebSocket(url)
-
-                        ws.addEventListener('open', () => {
-                            resolve(true)
-                        })
-
-                        ws.addEventListener('error', (e) => {
-                            reject(e)
-                        })
-                    }),
+                    new Promise<boolean>((resolve) => void resolve(!!url)),
                 ])
             } finally {
                 ws?.close()


### PR DESCRIPTION
The reachability check is back. It does not actually probe declared websocket connectivity information. It just checks if it's defined. Later on we'll bring back the real check.