### PR TITLE
FRONT-1657: Collect earnings fails when the wallet is not connected

### DIFF
--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -1,14 +1,12 @@
 import React, { Fragment, FunctionComponent, HTMLAttributes, useState } from 'react'
 import styled from 'styled-components'
-import { toaster } from 'toasterhea'
 import { useLocation, Link, useNavigate } from 'react-router-dom'
 import { Accordion, AccordionItem } from 'reactstrap'
 import { Button, HamburgerButton, Logo, NavOverlay } from '@streamr/streamr-layout'
 import { DESKTOP, TABLET } from '~/shared/utils/styled'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { truncate } from '~/shared/utils/text'
-import ConnectModal from '~/modals/ConnectModal'
-import { Layer } from '~/utils/Layer'
+import { connectModal } from '~/modals/ConnectModal'
 import { useEns, useWalletAccount } from '~/shared/stores/wallet'
 import toast from '~/utils/toast'
 import { FeatureFlag, isFeatureEnabled } from '~/shared/utils/isFeatureEnabled'
@@ -162,7 +160,7 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
                                 type="button"
                                 onClick={async () => {
                                     try {
-                                        await toaster(ConnectModal, Layer.Modal).pop()
+                                        await connectModal.pop()
                                     } catch (e) {
                                         console.warn('Wallet connecting failed', e)
                                     }
@@ -351,7 +349,7 @@ const UnstyledMobileNav: FunctionComponent<{ className?: string }> = ({ classNam
                         type="button"
                         onClick={async () => {
                             try {
-                                await toaster(ConnectModal, Layer.Modal).pop()
+                                await connectModal.pop()
                             } catch (e) {
                                 console.warn('Wallet connecting failed', e)
                             }

--- a/src/components/NetworkUtils.tsx
+++ b/src/components/NetworkUtils.tsx
@@ -1,11 +1,9 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components'
-import { toaster } from 'toasterhea'
 import moment from 'moment'
 import { randomHex } from 'web3-utils'
 import { WhiteBox, WhiteBoxPaddingStyles } from '~/shared/components/WhiteBox'
-import ConnectModal from '~/modals/ConnectModal'
-import { Layer } from '~/utils/Layer'
+import { connectModal } from '~/modals/ConnectModal'
 import Button from '~/shared/components/Button'
 import { COLORS, MD, MEDIUM } from '~/shared/utils/styled'
 import { SponsorshipElement } from '~/types/sponsorship'
@@ -103,7 +101,7 @@ export const WalletNotConnectedOverlay: FunctionComponent<{ summaryTitle: string
                     type="button"
                     onClick={async () => {
                         try {
-                            await toaster(ConnectModal, Layer.Modal).pop()
+                            await connectModal.pop()
                         } catch (e) {
                             console.warn('Wallet connecting failed', e)
                         }

--- a/src/components/NoWalletOverlay.tsx
+++ b/src/components/NoWalletOverlay.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
-import { toaster } from 'toasterhea'
 import styled from 'styled-components'
-import ConnectModal from '~/modals/ConnectModal'
+import { connectModal } from '~/modals/ConnectModal'
 import Button from '~/shared/components/Button'
-import { Layer } from '~/utils/Layer'
 import { COLORS } from '~/shared/utils/styled'
 
 export default function NoWalletOverlay({ resourceName }: { resourceName: string }) {
@@ -18,7 +16,7 @@ export default function NoWalletOverlay({ resourceName }: { resourceName: string
                     type="button"
                     onClick={async () => {
                         try {
-                            await toaster(ConnectModal, Layer.Modal).pop()
+                            await connectModal.pop()
                         } catch (e) {
                             console.warn('Wallet connecting failed', e)
                         }

--- a/src/modals/ChainSelectorModal.tsx
+++ b/src/modals/ChainSelectorModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
-import { toaster } from 'toasterhea'
 import Button from '~/shared/components/Button'
 import NetworkIcon from '~/shared/components/NetworkIcon'
 import { MEDIUM } from '~/shared/utils/styled'
@@ -10,11 +9,10 @@ import useIsMounted from '~/shared/hooks/useIsMounted'
 import { getCustomTokenBalance } from '~/marketplace/utils/web3'
 import { getTokenInfo } from '~/hooks/useTokenInfo'
 import { getUsdRate } from '~/shared/utils/coingecko'
-import { Layer } from '~/utils/Layer'
 import networkPreflight from '~/utils/networkPreflight'
 import { ParsedPaymentDetail } from '~/parsers/ProjectParser'
 import ProjectModal, { Actions } from './ProjectModal'
-import ConnectModal from './ConnectModal'
+import { connectModal } from './ConnectModal'
 import { RejectionReason } from './BaseModal'
 
 const ChainIcon = styled(NetworkIcon)`
@@ -129,7 +127,7 @@ export async function getPurchasePreconditions({
 
     const tokenInfo = await getTokenInfo(tokenAddress, chainId)
 
-    const account = await toaster(ConnectModal, Layer.Modal).pop()
+    const account = await connectModal.pop()
 
     if (!account) {
         throw new Error('No account')

--- a/src/modals/ConnectModal.tsx
+++ b/src/modals/ConnectModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { useDiscardableEffect, defer, Deferral } from 'toasterhea'
+import { useDiscardableEffect, defer, Deferral, toaster } from 'toasterhea'
 import { Link as PrestyledLink } from 'react-router-dom'
 import { Logo, Auth, SignInMethod, LoadingIndicator } from '@streamr/streamr-layout'
 import { MEDIUM, TABLET } from '~/shared/utils/styled'
@@ -10,6 +10,8 @@ import TimeoutError from '~/shared/errors/TimeoutError'
 import { getWalletAccount, useWalletAccount } from '~/shared/stores/wallet'
 import isCodedError from '~/utils/isCodedError'
 import routes from '~/routes'
+import { Layer } from '~/utils/Layer'
+import { RejectionReason } from './BaseModal'
 
 const Root = styled.div`
     background: #f8f8f8;
@@ -119,7 +121,7 @@ export default function ConnectModal({ onReject, onResolve }: Props) {
     useEffect(() => {
         function onKeyDown({ key }: KeyboardEvent) {
             if (key === 'Escape') {
-                onReject?.()
+                onReject?.(RejectionReason.EscapeKey)
             }
         }
 
@@ -278,3 +280,5 @@ export default function ConnectModal({ onReject, onResolve }: Props) {
         </Root>
     )
 }
+
+export const connectModal = toaster(ConnectModal, Layer.Modal)

--- a/src/pages/SingleOperatorPage.tsx
+++ b/src/pages/SingleOperatorPage.tsx
@@ -68,6 +68,7 @@ import { useSetBlockDependency } from '~/stores/blockNumberDependencies'
 import { blockObserver } from '~/utils/blocks'
 import { LiveNodesTable } from '~/components/LiveNodesTable'
 import { useInterceptHeartbeats } from '~/hooks/useInterceptHeartbeats'
+import { isTransactionRejection } from '~/utils'
 
 const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)
 const forceUndelegateModal = toaster(ForceUndelegateModal, Layer.Modal)
@@ -533,6 +534,10 @@ export const SingleOperatorPage = () => {
                                                         operatorId,
                                                     )
                                                 } catch (e) {
+                                                    if (isTransactionRejection(e)) {
+                                                        return
+                                                    }
+
                                                     console.error(
                                                         'Could not collect earnings',
                                                         e,

--- a/src/pages/SingleOperatorPage.tsx
+++ b/src/pages/SingleOperatorPage.tsx
@@ -69,6 +69,7 @@ import { blockObserver } from '~/utils/blocks'
 import { LiveNodesTable } from '~/components/LiveNodesTable'
 import { useInterceptHeartbeats } from '~/hooks/useInterceptHeartbeats'
 import { isTransactionRejection } from '~/utils'
+import { Break } from '~/utils/errors'
 
 const becomeOperatorModal = toaster(BecomeOperatorModal, Layer.Modal)
 const forceUndelegateModal = toaster(ForceUndelegateModal, Layer.Modal)
@@ -534,6 +535,10 @@ export const SingleOperatorPage = () => {
                                                         operatorId,
                                                     )
                                                 } catch (e) {
+                                                    if (e === Break) {
+                                                        return
+                                                    }
+
                                                     if (isTransactionRejection(e)) {
                                                         return
                                                     }

--- a/src/shared/stores/wallet.ts
+++ b/src/shared/stores/wallet.ts
@@ -4,9 +4,11 @@ import detectProvider from '@metamask/detect-provider'
 import { create } from 'zustand'
 import { providers } from 'ethers'
 import { MetaMaskInpageProvider } from '@metamask/providers'
-import { isEthereumAddress } from '~/utils'
+import { isEthereumAddress, isMessagedObject } from '~/utils'
 import { getFirstEnsNameFor } from '~/getters'
 import { getConfigForChain } from '~/shared/web3/config'
+import { connectModal } from '~/modals/ConnectModal'
+import { isRejectionReason } from '~/modals/BaseModal'
 
 interface MetaMaskProvider extends MetaMaskInpageProvider {
     providers?: MetaMaskProvider[]
@@ -55,7 +57,44 @@ export async function getWalletWeb3Provider() {
 }
 
 export async function getSigner() {
-    return (await getWalletWeb3Provider()).getSigner()
+    let retry = true
+
+    while (true) {
+        try {
+            const provider = await getWalletWeb3Provider()
+
+            const signer = provider.getSigner()
+
+            await signer.getAddress()
+
+            return signer
+        } catch (e) {
+            if (!retry) {
+                throw e
+            }
+
+            if (!isMessagedObject(e) || !/unknown account #\d+/i.test(e.message)) {
+                throw e
+            }
+
+            try {
+                await connectModal.pop()
+
+                /**
+                 * If after this it still fails to get a proper signer (with
+                 * an address and all) ignore further attempts and just
+                 * throw the error (see above).
+                 */
+                retry = false
+            } catch (f) {
+                if (isRejectionReason(f)) {
+                    throw new Error('User keeps wallet locked')
+                }
+
+                throw f
+            }
+        }
+    }
 }
 
 const promiseMap = new Map<MetaMaskProvider, Promise<string | undefined>>()

--- a/src/shared/stores/wallet.ts
+++ b/src/shared/stores/wallet.ts
@@ -9,6 +9,7 @@ import { getFirstEnsNameFor } from '~/getters'
 import { getConfigForChain } from '~/shared/web3/config'
 import { connectModal } from '~/modals/ConnectModal'
 import { isRejectionReason } from '~/modals/BaseModal'
+import { Break } from '~/utils/errors'
 
 interface MetaMaskProvider extends MetaMaskInpageProvider {
     providers?: MetaMaskProvider[]
@@ -88,7 +89,11 @@ export async function getSigner() {
                 retry = false
             } catch (f) {
                 if (isRejectionReason(f)) {
-                    throw new Error('User keeps wallet locked')
+                    /**
+                     * The user kept their wallet locked and there's nothing
+                     * we can do. Let's break.
+                     */
+                    throw Break
                 }
 
                 throw f

--- a/src/shared/test/components/Nav/nav.test.tsx
+++ b/src/shared/test/components/Nav/nav.test.tsx
@@ -10,7 +10,7 @@ jest.mock('~/shared/stores/wallet', () => ({
     useEns: jest.fn(),
 }))
 
-jest.mock('~//modals/ConnectModal', () => ({
+jest.mock('~/modals/ConnectModal', () => ({
     __esModule: true,
     default: () => <></>,
 }))

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,9 @@
 /**
+ * Been dealt with. Ignore it if you catch it.
+ */
+export const Break = Object.freeze({})
+
+/**
  * Flagged flow is already being processed.
  */
 export const FlagBusy = Object.freeze({})


### PR DESCRIPTION
Few extras:
- `ConnectModal` is now represented by a single toaster instance. 1 is enough.
- `getSigner` will always verify if the wallet is unlocked and pop up the "Connect wallet" modal if it isn't.