### PR TITLE
[FRONT-1675] Allow decimal values for token amounts

### DIFF
--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -212,6 +212,7 @@ export default function CreateSponsorshipModal({
                             readOnly={busy}
                             type="number"
                             min={0}
+                            step="any"
                             value={initialAmount || ''}
                         />
                         <TextAppendix>
@@ -241,6 +242,7 @@ export default function CreateSponsorshipModal({
                             readOnly={busy}
                             type="number"
                             min={0}
+                            step="any"
                             value={payoutRate || ''}
                         />
                         <TextAppendix>

--- a/src/modals/DelegateFundsModal.tsx
+++ b/src/modals/DelegateFundsModal.tsx
@@ -172,6 +172,7 @@ export default function DelegateFundsModal({
                         readOnly={busy}
                         type="number"
                         min={0}
+                        step="any"
                         value={rawAmount}
                     />
                     <TextAppendix>

--- a/src/modals/EditStakeModal.tsx
+++ b/src/modals/EditStakeModal.tsx
@@ -155,6 +155,7 @@ export default function EditStakeModal({
                         readOnly={busy}
                         type="number"
                         min={0}
+                        step="any"
                         value={rawAmount}
                     />
                     <TextAppendix>{tokenSymbol}</TextAppendix>

--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -153,6 +153,7 @@ export default function FundSponsorshipModal({
                         readOnly={busy}
                         type="number"
                         min={0}
+                        step="any"
                         value={rawAmount}
                     />
                     <TextAppendix>{tokenSymbol}</TextAppendix>

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -210,6 +210,7 @@ export default function JoinSponsorshipModal({
                         readOnly={busy}
                         type="number"
                         min={0}
+                        step="any"
                         value={rawAmount}
                     />
                     <TextAppendix>{tokenSymbol}</TextAppendix>

--- a/src/modals/UndelegateFundsModal.tsx
+++ b/src/modals/UndelegateFundsModal.tsx
@@ -151,6 +151,7 @@ export default function UndelegateFundsModal({
                         readOnly={busy}
                         type="number"
                         min={0}
+                        step="any"
                         value={rawAmount}
                     />
                     <TextAppendix>


### PR DESCRIPTION
Found a couple of places where step was not specified and thus defaulting to `1`. Now we allow entering decimal values for token amounts.