### PR TITLE
FRONt-1683: Fix the "new end date" calculation in the "Fund sponsorship" modal

### DIFF
--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -97,7 +97,12 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
         )} & ${days} ${pluralizeUnit(days, 'day')}`
     }, [extensionDuration])
 
-    const endDate = new Date(Date.now() + extensionInSeconds * 1000)
+    const startDate =
+        sponsorship.projectedInsolvencyAt == null
+            ? Date.now()
+            : sponsorship.projectedInsolvencyAt * 1000
+
+    const endDate = new Date(startDate + extensionInSeconds * 1000)
 
     const insufficientFunds = finalValue.isGreaterThan(toDecimals(balance, decimals))
 


### PR DESCRIPTION
The new end date extends the current end date, and not *today's* date.