### PR TITLE
Wait for block after funds delegation

### DIFF
--- a/src/components/ActionBars/OperatorActionBar.tsx
+++ b/src/components/ActionBars/OperatorActionBar.tsx
@@ -51,8 +51,7 @@ import { SponsorshipPaymentTokenName } from '../SponsorshipPaymentTokenName'
 export const OperatorActionBar: FunctionComponent<{
     operator: ParsedOperator
     handleEdit: (operator: ParsedOperator) => void
-    onDelegationChange: () => void
-}> = ({ operator, handleEdit, onDelegationChange }) => {
+}> = ({ operator, handleEdit }) => {
     const heartbeats = useInterceptHeartbeats(operator.id)
 
     const { count: liveNodeCount, isLoading: liveNodeCountIsLoading } =
@@ -171,7 +170,6 @@ export const OperatorActionBar: FunctionComponent<{
                                 delegateFunds({
                                     operator,
                                     wallet: walletAddress,
-                                    onDone: onDelegationChange,
                                 })
                             }}
                             disabled={!walletAddress}
@@ -184,7 +182,6 @@ export const OperatorActionBar: FunctionComponent<{
                                 undelegateFunds({
                                     operator,
                                     wallet: walletAddress,
-                                    onDone: onDelegationChange,
                                 })
                             }}
                             disabled={!canUndelegate}

--- a/src/hooks/operators.ts
+++ b/src/hooks/operators.ts
@@ -436,7 +436,7 @@ export function useDelegateFunds() {
                                     delegatedTotal,
                                 })
 
-                                await waitForGraphSync()
+                                invalidateActiveOperatorByIdQueries(operator.id)
                             },
                         )
                     } catch (e) {
@@ -521,7 +521,7 @@ export function useUndelegateFunds() {
                                     delegatedTotal,
                                 })
 
-                                await waitForGraphSync()
+                                invalidateActiveOperatorByIdQueries(operator.id)
                             },
                         )
                     } catch (e) {

--- a/src/modals/DelegateFundsModal.tsx
+++ b/src/modals/DelegateFundsModal.tsx
@@ -21,7 +21,7 @@ import { useConfigValueFromChain } from '~/hooks'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { delegateToOperator } from '~/services/operators'
-import { isTransactionRejection } from '~/utils'
+import { isTransactionRejection, waitForIndexedBlock } from '~/utils'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
     amount?: string
@@ -138,7 +138,8 @@ export default function DelegateFundsModal({
                 try {
                     await delegateToOperator(
                         operator.id,
-                        toDecimals(finalValue, decimals).toString(),
+                        toDecimals(finalValue, decimals),
+                        { onBlockNumber: waitForIndexedBlock },
                     )
 
                     onResolve?.()

--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -20,7 +20,7 @@ import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 import { toDecimals } from '~/marketplace/utils/math'
 import { fundSponsorship } from '~/services/sponsorships'
-import { isTransactionRejection } from '~/utils'
+import { isTransactionRejection, waitForIndexedBlock } from '~/utils'
 import { blockObserver } from '~/utils/blocks'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
@@ -128,11 +128,7 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
 
                 try {
                     await fundSponsorship(sponsorship.id, finalValue, {
-                        onBlockNumber(blockNumber) {
-                            return new Promise<void>((resolve) => {
-                                blockObserver.onSpecific(blockNumber, resolve)
-                            })
-                        },
+                        onBlockNumber: waitForIndexedBlock,
                     })
 
                     onResolve?.()

--- a/src/pages/SingleOperatorPage.tsx
+++ b/src/pages/SingleOperatorPage.tsx
@@ -174,9 +174,6 @@ export const SingleOperatorPage = () => {
                     handleEdit={(currentOperator) => {
                         saveOperator(currentOperator)
                     }}
-                    onDelegationChange={() => {
-                        invalidateActiveOperatorByIdQueries(operator.id)
-                    }}
                 />
             )}
             <LayoutColumn>

--- a/src/services/operators.ts
+++ b/src/services/operators.ts
@@ -201,7 +201,7 @@ export async function updateOperator(
 export async function delegateToOperator(
     operatorId: string,
     amount: BNish,
-    options: { onBlockNumber?: (blockNumber?: number) => void | Promise<void> } = {},
+    options: { onBlockNumber?: (blockNumber: number) => void | Promise<void> } = {},
 ): Promise<void> {
     const chainId = getOperatorChainId()
 
@@ -231,7 +231,7 @@ export async function delegateToOperator(
 export async function undelegateFromOperator(
     operatorId: string,
     amount: BNish,
-    options: { onBlockNumber?: (blockNumber?: number) => void | Promise<void> } = {},
+    options: { onBlockNumber?: (blockNumber: number) => void | Promise<void> } = {},
 ): Promise<void> {
     const chainId = getOperatorChainId()
 


### PR DESCRIPTION
This one is simple because the associated modals have already been refactored and simplified.