### PR TITLE
Make operators by searchable by sponsorships and vice versa

### DIFF
--- a/src/generated/gql/network.ts
+++ b/src/generated/gql/network.ts
@@ -4430,21 +4430,11 @@ export type GetAllOperatorsQueryVariables = Exact<{
 
 export type GetAllOperatorsQuery = { __typename?: 'Query', operators: Array<{ __typename?: 'Operator', id: string, delegatorCount: number, valueWithoutEarnings: any, totalStakeInSponsorshipsWei: any, dataTokenBalanceWei: any, operatorTokenTotalSupplyWei: any, exchangeRate: any, metadataJsonString: string, owner: string, nodes: Array<string>, cumulativeProfitsWei: any, cumulativeOperatorsCutWei: any, operatorsCutFraction: any, stakes: Array<{ __typename?: 'Stake', amountWei: any, earningsWei: any, joinTimestamp: number, operator: { __typename?: 'Operator', id: string }, sponsorship: { __typename?: 'Sponsorship', id: string, metadata?: string | null, isRunning: boolean, totalPayoutWeiPerSec: any, operatorCount: number, maxOperators?: number | null, totalStakedWei: any, remainingWei: any, projectedInsolvency?: any | null, cumulativeSponsoring: any, minimumStakingPeriodSeconds: any, creator: string, spotAPY: any, stream?: { __typename?: 'Stream', id: string, metadata: string } | null, stakes: Array<{ __typename?: 'Stake', amountWei: any, earningsWei: any, joinTimestamp: number, operator: { __typename?: 'Operator', id: string, metadataJsonString: string } }> } }>, delegations: Array<{ __typename?: 'Delegation', valueDataWei: any, operatorTokenBalanceWei: any, id: string, delegator: { __typename?: 'Delegator', id: string } }>, slashingEvents: Array<{ __typename?: 'SlashingEvent', amount: any, date: any, sponsorship: { __typename?: 'Sponsorship', id: string, stream?: { __typename?: 'Stream', id: string } | null } }>, queueEntries: Array<{ __typename?: 'QueueEntry', amount: any, date: any, id: string, delegator: { __typename?: 'Delegator', id: string } }> }> };
 
-export type SearchOperatorsByIdQueryVariables = Exact<{
-  first?: InputMaybe<Scalars['Int']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  operatorId?: InputMaybe<Scalars['ID']['input']>;
-  orderBy?: InputMaybe<Operator_OrderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-}>;
-
-
-export type SearchOperatorsByIdQuery = { __typename?: 'Query', operators: Array<{ __typename?: 'Operator', id: string, delegatorCount: number, valueWithoutEarnings: any, totalStakeInSponsorshipsWei: any, dataTokenBalanceWei: any, operatorTokenTotalSupplyWei: any, exchangeRate: any, metadataJsonString: string, owner: string, nodes: Array<string>, cumulativeProfitsWei: any, cumulativeOperatorsCutWei: any, operatorsCutFraction: any, stakes: Array<{ __typename?: 'Stake', amountWei: any, earningsWei: any, joinTimestamp: number, operator: { __typename?: 'Operator', id: string }, sponsorship: { __typename?: 'Sponsorship', id: string, metadata?: string | null, isRunning: boolean, totalPayoutWeiPerSec: any, operatorCount: number, maxOperators?: number | null, totalStakedWei: any, remainingWei: any, projectedInsolvency?: any | null, cumulativeSponsoring: any, minimumStakingPeriodSeconds: any, creator: string, spotAPY: any, stream?: { __typename?: 'Stream', id: string, metadata: string } | null, stakes: Array<{ __typename?: 'Stake', amountWei: any, earningsWei: any, joinTimestamp: number, operator: { __typename?: 'Operator', id: string, metadataJsonString: string } }> } }>, delegations: Array<{ __typename?: 'Delegation', valueDataWei: any, operatorTokenBalanceWei: any, id: string, delegator: { __typename?: 'Delegator', id: string } }>, slashingEvents: Array<{ __typename?: 'SlashingEvent', amount: any, date: any, sponsorship: { __typename?: 'Sponsorship', id: string, stream?: { __typename?: 'Stream', id: string } | null } }>, queueEntries: Array<{ __typename?: 'QueueEntry', amount: any, date: any, id: string, delegator: { __typename?: 'Delegator', id: string } }> }> };
-
 export type SearchOperatorsByMetadataQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
   orderBy?: InputMaybe<Operator_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
 }>;
@@ -4841,26 +4831,12 @@ export const GetAllOperatorsDocument = gql`
 }
     ${OperatorFieldsFragmentDoc}`;
 export type GetAllOperatorsQueryResult = Apollo.QueryResult<GetAllOperatorsQuery, GetAllOperatorsQueryVariables>;
-export const SearchOperatorsByIdDocument = gql`
-    query searchOperatorsById($first: Int, $skip: Int, $operatorId: ID, $orderBy: Operator_orderBy, $orderDirection: OrderDirection) {
-  operators(
-    first: $first
-    skip: $skip
-    where: {id: $operatorId}
-    orderBy: $orderBy
-    orderDirection: $orderDirection
-  ) {
-    ...OperatorFields
-  }
-}
-    ${OperatorFieldsFragmentDoc}`;
-export type SearchOperatorsByIdQueryResult = Apollo.QueryResult<SearchOperatorsByIdQuery, SearchOperatorsByIdQueryVariables>;
 export const SearchOperatorsByMetadataDocument = gql`
-    query searchOperatorsByMetadata($first: Int, $skip: Int, $searchQuery: String, $orderBy: Operator_orderBy, $orderDirection: OrderDirection) {
+    query searchOperatorsByMetadata($first: Int, $skip: Int, $searchQuery: String, $id: ID!, $orderBy: Operator_orderBy, $orderDirection: OrderDirection) {
   operators(
     first: $first
     skip: $skip
-    where: {metadataJsonString_contains_nocase: $searchQuery}
+    where: {or: [{id: $id}, {metadataJsonString_contains_nocase: $searchQuery}, {stakes_: {sponsorship_contains_nocase: $searchQuery}}]}
     orderBy: $orderBy
     orderDirection: $orderDirection
   ) {
@@ -4932,7 +4908,7 @@ export const GetAllSponsorshipsDocument = gql`
   sponsorships(
     first: $first
     skip: $skip
-    where: {or: [{stream_contains_nocase: $searchQuery}, {id: $id}]}
+    where: {or: [{stream_contains_nocase: $searchQuery}, {id: $id}, {stakes_: {operator_contains_nocase: $searchQuery}}]}
     orderBy: $orderBy
     orderDirection: $orderDirection
   ) {
@@ -4946,7 +4922,7 @@ export const GetSponsorshipsByCreatorDocument = gql`
   sponsorships(
     first: $first
     skip: $skip
-    where: {and: [{creator: $creator}, {or: [{stream_contains_nocase: $searchQuery}, {id: $id}]}]}
+    where: {and: [{creator: $creator}, {or: [{stream_contains_nocase: $searchQuery}, {id: $id}, {stakes_: {operator_contains_nocase: $searchQuery}}]}]}
     orderBy: $orderBy
     orderDirection: $orderDirection
   ) {

--- a/src/getters/index.ts
+++ b/src/getters/index.ts
@@ -43,9 +43,6 @@ import {
     GetOperatorByOwnerAddressQuery,
     GetOperatorByOwnerAddressQueryVariables,
     GetOperatorByOwnerAddressDocument,
-    SearchOperatorsByIdQuery,
-    SearchOperatorsByIdQueryVariables,
-    SearchOperatorsByIdDocument,
     SearchOperatorsByMetadataQuery,
     SearchOperatorsByMetadataQueryVariables,
     SearchOperatorsByMetadataDocument,
@@ -527,41 +524,6 @@ export async function getOperatorsByDelegationAndMetadata({
     return operators
 }
 
-export async function searchOperatorsById({
-    first,
-    skip,
-    operatorId,
-    orderBy = DEFAULT_OPERATOR_ORDER_BY,
-    orderDirection = DEFAULT_ORDER_DIRECTION,
-    force = false,
-}: {
-    first?: number
-    skip?: number
-    operatorId?: string
-    orderBy?: Operator_OrderBy
-    orderDirection?: OrderDirection
-    force?: boolean
-}): Promise<SearchOperatorsByIdQuery['operators']> {
-    const {
-        data: { operators },
-    } = await getGraphClient().query<
-        SearchOperatorsByIdQuery,
-        SearchOperatorsByIdQueryVariables
-    >({
-        query: SearchOperatorsByIdDocument,
-        variables: {
-            first,
-            skip,
-            operatorId,
-            orderBy,
-            orderDirection,
-        },
-        fetchPolicy: force ? 'network-only' : void 0,
-    })
-
-    return operators
-}
-
 export async function searchOperatorsByMetadata({
     first,
     skip,
@@ -588,6 +550,7 @@ export async function searchOperatorsByMetadata({
             first,
             skip,
             searchQuery,
+            id: searchQuery?.toLowerCase() || '',
             orderBy,
             orderDirection,
         },

--- a/src/hooks/operators.ts
+++ b/src/hooks/operators.ts
@@ -14,7 +14,6 @@ import {
     getParsedOperatorByOwnerAddress,
     getParsedOperators,
     getSpotApy,
-    searchOperatorsById,
     searchOperatorsByMetadata,
 } from '~/getters'
 import { getQueryClient } from '~/utils'
@@ -330,13 +329,6 @@ export function useAllOperatorsQuery({
 
                     if (!searchQuery) {
                         return getAllOperators(params) as Promise<Operator[]>
-                    }
-
-                    if (isAddress(searchQuery)) {
-                        return searchOperatorsById({
-                            ...params,
-                            operatorId: searchQuery,
-                        }) as Promise<Operator[]>
                     }
 
                     return searchOperatorsByMetadata({

--- a/src/queries/network.ts
+++ b/src/queries/network.ts
@@ -71,35 +71,24 @@ gql`
         }
     }
 
-    query searchOperatorsById(
-        $first: Int
-        $skip: Int
-        $operatorId: ID
-        $orderBy: Operator_orderBy
-        $orderDirection: OrderDirection
-    ) {
-        operators(
-            first: $first
-            skip: $skip
-            where: { id: $operatorId }
-            orderBy: $orderBy
-            orderDirection: $orderDirection
-        ) {
-            ...OperatorFields
-        }
-    }
-
     query searchOperatorsByMetadata(
         $first: Int
         $skip: Int
         $searchQuery: String
+        $id: ID!
         $orderBy: Operator_orderBy
         $orderDirection: OrderDirection
     ) {
         operators(
             first: $first
             skip: $skip
-            where: { metadataJsonString_contains_nocase: $searchQuery }
+            where: {
+                or: [
+                    { id: $id }
+                    { metadataJsonString_contains_nocase: $searchQuery }
+                    { stakes_: { sponsorship_contains_nocase: $searchQuery } }
+                ]
+            }
             orderBy: $orderBy
             orderDirection: $orderDirection
         ) {
@@ -220,7 +209,13 @@ gql`
         sponsorships(
             first: $first
             skip: $skip
-            where: { or: [{ stream_contains_nocase: $searchQuery }, { id: $id }] }
+            where: {
+                or: [
+                    { stream_contains_nocase: $searchQuery }
+                    { id: $id }
+                    { stakes_: { operator_contains_nocase: $searchQuery } }
+                ]
+            }
             orderBy: $orderBy
             orderDirection: $orderDirection
         ) {
@@ -243,7 +238,13 @@ gql`
             where: {
                 and: [
                     { creator: $creator }
-                    { or: [{ stream_contains_nocase: $searchQuery }, { id: $id }] }
+                    {
+                        or: [
+                            { stream_contains_nocase: $searchQuery }
+                            { id: $id }
+                            { stakes_: { operator_contains_nocase: $searchQuery } }
+                        ]
+                    }
                 ]
             }
             orderBy: $orderBy


### PR DESCRIPTION
With this, additionally,
- Users can search operators by sponsorship id as well as
- Search sponsorships by operator id.

Similar information is shown on individual sponsorship/operator pages but being able to search from the listing page allows users to sort and scout for interesting things from a single spot.

As an extra, I removed redundant query (search operators by id) because I wrap the following interactions into a single (existing) query:
- searching by metadata,
- searching by a operator id, and
- searching by a sponsorship id.

Onwards!