### PR TITLE
FRONT-1725: Fix `parseStreamId` throwing when stream owner is an ENS domain

### DIFF
--- a/src/shared/utils/text.test.ts
+++ b/src/shared/utils/text.test.ts
@@ -1,10 +1,10 @@
-import { truncate, truncateStreamName } from '~/shared/utils/text'
+import { truncate, truncateStreamName } from './text'
 describe('text utils', () => {
     describe('truncate', () => {
         it('does not truncate non-strings', () => {
-            expect(truncate(undefined)).toBe(undefined)
             expect(truncate('123')).toBe('123')
         })
+
         it('does not truncate hashes that are too short', () => {
             expect(truncate('0x0123456789abcdef0123456789abcdef01234567')).toBe(
                 '0x012...34567',
@@ -13,10 +13,12 @@ describe('text utils', () => {
                 '0x0123456789abcdef0123456789abcdef0123456',
             )
         })
+
         it('does not truncate non-eth address', () => {
             expect(truncate('sandbox/test/my-stream')).toBe('sandbox/test/my-stream')
             expect(truncate('FwhuQBTrtfkddf2542asd')).toBe('FwhuQBTrtfkddf2542asd')
         })
+
         it('truncates paths starting with eth address', () => {
             expect(
                 truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/test/my-stream'),
@@ -25,6 +27,7 @@ describe('text utils', () => {
                 truncate('0xA3D1F77ACFF0060F7213D7BF3C7fEC78DF847DE1/test/my-stream'),
             ).toBe('0xA3D...47DE1/test/my-stream')
         })
+
         it('truncates address in the middle of text', () => {
             expect(
                 truncate(
@@ -32,6 +35,7 @@ describe('text utils', () => {
                 ),
             ).toBe('address is 0xA3D...47DE1 inside text')
         })
+
         it('truncates paths with mutiple eth address', () => {
             expect(
                 truncate(
@@ -39,11 +43,13 @@ describe('text utils', () => {
                 ),
             ).toBe('0xa3d...47De1/test/0x135...B5E03/path')
         })
+
         it('only truncates valid eth addresses', () => {
             expect(truncate('0xa3d1F77ACfF3c7fEC78df847De1/test/my-stream')).toBe(
                 '0xa3d1F77ACfF3c7fEC78df847De1/test/my-stream',
             )
         })
+
         it('truncates single eth address', () => {
             expect(truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1')).toBe(
                 '0xa3d...47De1',
@@ -52,6 +58,7 @@ describe('text utils', () => {
                 '0xA3D...47DE1',
             )
         })
+
         it('truncates transaction hash', () => {
             expect(
                 truncate(

--- a/src/shared/utils/text.test.ts
+++ b/src/shared/utils/text.test.ts
@@ -1,4 +1,4 @@
-import { truncate, truncateStreamName } from './text'
+import { truncate, truncateStreamName, parseStreamId as psi } from './text'
 describe('text utils', () => {
     describe('truncate', () => {
         it('does not truncate non-strings', () => {
@@ -104,6 +104,43 @@ describe('text utils', () => {
                     testCase.expectedOutput,
                 )
             })
+        })
+    })
+
+    describe('parseStreamId', () => {
+        it('parses different stream ids correctly', () => {
+            expect(psi('owner/pathname')).toMatchObject({
+                owner: 'owner',
+                pathname: '/pathname',
+            })
+
+            expect(
+                psi('0x0000000000000000000000000000000000000001/stream-id'),
+            ).toMatchObject({
+                owner: '0x0000000000000000000000000000000000000001',
+                pathname: '/stream-id',
+            })
+
+            expect(psi('ens-domain.eth/stream-id')).toMatchObject({
+                owner: 'ens-domain.eth',
+                pathname: '/stream-id',
+            })
+        })
+
+        it('explodes on invalid stream ids', () => {
+            expect(() => psi('')).toThrow(/invalid/i)
+
+            expect(() => psi(' /')).toThrow(/invalid/i)
+
+            expect(() => psi('/ ')).toThrow(/invalid/i)
+
+            expect(() => psi(' / ')).toThrow(/invalid/i)
+
+            expect(() => psi('/')).toThrow(/invalid/i)
+
+            expect(() => psi('/whatever')).toThrow(/invalid/i)
+
+            expect(() => psi('whatever/')).toThrow(/invalid/i)
         })
     })
 })

--- a/src/shared/utils/text.ts
+++ b/src/shared/utils/text.ts
@@ -23,7 +23,7 @@ export function parseStreamId(streamId: string): {
     pathname: string
 } {
     try {
-        const [, owner, pathname] = streamId.match(/^(0x[a-f\d]{40})([^\s]+)$/)!
+        const [, owner, pathname] = streamId.match(/^([^/]+)([^\s]+)$/)!
 
         return {
             owner,

--- a/src/shared/utils/text.ts
+++ b/src/shared/utils/text.ts
@@ -23,7 +23,7 @@ export function parseStreamId(streamId: string): {
     pathname: string
 } {
     try {
-        const [, owner, pathname] = streamId.match(/^([^/]+)([^\s]+)$/)!
+        const [, owner, pathname] = streamId.match(/^([^/]+)(\/[^\s]+)$/)!
 
         return {
             owner,


### PR DESCRIPTION
Made the util more loose and flexible.