### PR TITLE
FRONT-1743: Look up ENS domains using the owner address

### DIFF
--- a/src/generated/gql/ens.ts
+++ b/src/generated/gql/ens.ts
@@ -4662,7 +4662,7 @@ export type GetEnsDomainsForAccountQuery = { __typename?: 'Query', domains: Arra
 
 export const GetEnsDomainsForAccountDocument = gql`
     query getEnsDomainsForAccount($account: String!) {
-  domains(where: {resolvedAddress: $account}, orderBy: name) {
+  domains(where: {owner_in: [$account]}, orderBy: name) {
     name
   }
 }

--- a/src/queries/ens.ts
+++ b/src/queries/ens.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client'
 
 gql`
     query getEnsDomainsForAccount($account: String!) {
-        domains(where: { resolvedAddress: $account }, orderBy: name) {
+        domains(where: { owner_in: [$account] }, orderBy: name) {
             name
         }
     }


### PR DESCRIPTION
Lines up with contracts this way so other ways are simply incorrect.