### PR TITLE
[FRONT-1740] Mobile overflow fixes

### DIFF
--- a/src/components/ActionBars/AboutEntity.tsx
+++ b/src/components/ActionBars/AboutEntity.tsx
@@ -7,7 +7,7 @@ export const Address = styled.div`
     display: grid;
     font-size: 14px;
     gap: 4px;
-    grid-template-columns: max-content max-content;
+    grid-template-columns: max-content minmax(150px, max-content) 16px;
     line-height: 20px;
 
     p + & {

--- a/src/components/ActionBars/AboutOperator.tsx
+++ b/src/components/ActionBars/AboutOperator.tsx
@@ -21,8 +21,9 @@ export function AboutOperator({ operator }: { operator: ParsedOperator }) {
         <DefaultSimpleDropdownMenu>
             {(description || null) && <p>{description}</p>}
             <Address>
+                <div>Owner wallet address:</div>
                 <div>
-                    Owner wallet address: <strong>{truncate(owner)}</strong>
+                    <strong>{truncate(owner)}</strong>
                 </div>
                 <div>
                     <IconButton type="button" onClick={() => void copy(owner)}>

--- a/src/components/ActionBars/AboutSponsorship.tsx
+++ b/src/components/ActionBars/AboutSponsorship.tsx
@@ -17,9 +17,10 @@ export function AboutSponsorship({ sponsorship }: { sponsorship: ParsedSponsorsh
         <DefaultSimpleDropdownMenu>
             {streamId && (
                 <Address>
-                    <div>
-                        Sponsored stream: <strong>{truncateStreamName(streamId)}</strong>
-                    </div>
+                    <div>Sponsored stream:</div>
+                    <StreamName>
+                        <strong>{truncateStreamName(streamId)}</strong>
+                    </StreamName>
                     <div>
                         <Link to={routes.streams.show({ id: streamId })} target="_blank">
                             <ExternalLinkIcon />
@@ -51,6 +52,10 @@ export function AboutSponsorship({ sponsorship }: { sponsorship: ParsedSponsorsh
         </DefaultSimpleDropdownMenu>
     )
 }
+
+const StreamName = styled.div`
+    overflow: hidden;
+`
 
 const Link = styled(PrestyledLink)`
     display: block;

--- a/src/components/ActionBars/NetworkActionBar.styles.tsx
+++ b/src/components/ActionBars/NetworkActionBar.styles.tsx
@@ -52,6 +52,7 @@ export const NetworkActionBarBackButtonIcon = styled(SvgIcon)`
 export const NetworkActionBarBackButtonAndTitle = styled.div`
     display: flex;
     align-items: center;
+    max-width: 100%;
 `
 
 export const NetworkActionBarTitle = styled.div`
@@ -61,8 +62,12 @@ export const NetworkActionBarTitle = styled.div`
     margin: 0;
     display: flex;
     gap: 10px;
-    justify-content: center;
+    justify-content: left;
     align-items: center;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 `
 
 export const NetworkActionBarInfoButtons = styled.div`

--- a/src/components/SimpleDropdown.tsx
+++ b/src/components/SimpleDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
-import { COLORS } from '~/shared/utils/styled'
+import { COLORS, TABLET } from '~/shared/utils/styled'
 
 type ChildrenFormatter =
     | ReactNode
@@ -109,22 +109,36 @@ export const SimpleDropdownMenu = styled.div<{ $visible?: boolean }>`
     min-width: 16px;
     opacity: 0;
     pointer-events: none;
-    position: absolute;
-    transform: translateY(-8px);
+    position: fixed;
+    left: 50%;
+    transform: translateY(-8px) translateX(-50%);
     transition: 250ms;
     transition-delay: 250ms, 0s, 0s;
     transition-property: visibility, opacity, transform;
     visibility: hidden;
     z-index: 1000;
 
+    @media ${TABLET} {
+        position: absolute;
+        left: auto;
+        transform: translateY(-8px);
+    }
+
     ${({ $visible = false }) =>
         $visible &&
         css`
             opacity: 1;
             pointer-events: auto;
-            transform: translateY(0);
+            left: 50%;
+            transform: translateY(0) translateX(-50%);
             visibility: visible;
             transition-delay: 0s;
+
+            @media ${TABLET} {
+                position: absolute;
+                left: auto;
+                transform: translateY(0);
+            }
         `}
 `
 
@@ -156,5 +170,10 @@ export const SimpleListDropdownMenu = styled.div`
 
 export const DefaultSimpleDropdownMenu = styled(SimpleListDropdownMenu)`
     padding: 20px 16px;
-    width: 460px;
+    max-width: 100vw;
+    width: auto;
+
+    @media ${TABLET} {
+        width: 460px;
+    }
 `

--- a/src/components/Tip.tsx
+++ b/src/components/Tip.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
+import { DESKTOP } from '~/shared/utils/styled'
 
 type Shift = 'left' | 'right'
 
@@ -32,7 +33,7 @@ const TipBody = styled.div`
     pointer-events: none;
     position: absolute;
     top: 0;
-    transform: translateY(-100%) translateX(-50%);
+    transform: translateY(-100%) translateX(-100%) translateX(24px);
     transition: 350ms;
     transition-property: visibility, opacity, transform;
     transition-delay: 350ms, 0s, 0s;
@@ -104,9 +105,9 @@ const TipEffects = styled.div`
         width: 16px;
         height: 16px;
         border-radius: 2px;
-        left: 50%;
         top: 100%;
-        transform: translate(-50%, -50%) translateY(-4px) rotate(45deg);
+        left: 100%;
+        transform: translate(-50%, -50%) translateX(-24px) translateY(-4px) rotate(45deg);
     }
 `
 
@@ -118,45 +119,63 @@ export const TipRoot = styled.div<{ $shift?: Shift }>`
         opacity: 1;
         visibility: visible;
         transition-delay: 0s;
-        transform: translateY(-100%) translateY(-8px) translateX(-50%);
+        transform: translateY(-100%) translateX(-100%) translateX(24px) translateY(-8px);
     }
 
-    ${({ $shift }) =>
-        $shift === 'left' &&
-        css`
-            ${TipEffects}::before {
-                left: 100%;
-                transform: translate(-50%, -50%) translateX(-24px) translateY(-4px)
-                    rotate(45deg);
-            }
+    // Default to center only after DESKTOP
+    @media ${DESKTOP} {
+        ${TipEffects}::before {
+            left: 50%;
+            transform: translate(-50%, -50%) translateY(-4px) rotate(45deg);
+        }
 
-            ${TipBody} {
-                transform: translateY(-100%) translateX(-100%) translateX(24px);
-            }
+        :hover ${TipBody} {
+            transform: translateY(-100%) translateY(-8px) translateX(-50%);
+        }
 
-            :hover ${TipBody} {
-                transform: translateY(-100%) translateX(-100%) translateX(24px)
-                    translateY(-8px);
-            }
-        `}
+        ${TipBody} {
+            transform: translateY(-100%) translateX(-50%);
+        }
 
-    ${({ $shift }) =>
-        $shift === 'right' &&
-        css`
-            ${TipEffects}::before {
-                left: 0%;
-                transform: translate(-50%, -50%) translateX(24px) translateY(-4px)
-                    rotate(45deg);
-            }
+        // Allow shifting only after DESKTOP because it will overflow the page
+        // on smaller screens
+        ${({ $shift }) =>
+            $shift === 'left' &&
+            css`
+                ${TipEffects}::before {
+                    left: 100%;
+                    transform: translate(-50%, -50%) translateX(-24px) translateY(-4px)
+                        rotate(45deg);
+                }
 
-            ${TipBody} {
-                transform: translateY(-100%) translateX(-24px);
-            }
+                ${TipBody} {
+                    transform: translateY(-100%) translateX(-100%) translateX(24px);
+                }
 
-            :hover ${TipBody} {
-                transform: translateY(-100%) translateX(-24px) translateY(-8px);
-            }
-        `}
+                :hover ${TipBody} {
+                    transform: translateY(-100%) translateX(-100%) translateX(24px)
+                        translateY(-8px);
+                }
+            `}
+
+        ${({ $shift }) =>
+            $shift === 'right' &&
+            css`
+                ${TipEffects}::before {
+                    left: 0%;
+                    transform: translate(-50%, -50%) translateX(24px) translateY(-4px)
+                        rotate(45deg);
+                }
+
+                ${TipBody} {
+                    transform: translateY(-100%) translateX(-24px);
+                }
+
+                :hover ${TipBody} {
+                    transform: translateY(-100%) translateX(-24px) translateY(-8px);
+                }
+            `}
+    }
 `
 
 export const TipIconWrap = styled.div<{
@@ -176,4 +195,5 @@ export const TipIconWrap = styled.div<{
                 `
             }
         }}
+    }
 `


### PR DESCRIPTION
A couple of fixes that caused sponsorship and operators page to overflow on mobile.

1. Tips are forced to left shift on mobile
2. About dropdowns are now centered on mobile
3. Long sponsorship/operator names are no more overflowing