### PR TITLE
FRONT-1720: Add operator CTAs to account menu

### DIFF
--- a/src/components/Nav/Nav.styles.tsx
+++ b/src/components/Nav/Nav.styles.tsx
@@ -34,23 +34,33 @@ const DropdownToggle = styled.div`
     }
 `
 export const Menu = styled(UnstyledMenu)``
-export const MenuItem = styled(Menu.Item)`
-    &.user-info {
-        padding: 0 16px !important;
+
+export const TextMenuItem = styled(Menu.Item)`
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    padding: 12px 16px !important;
+
+    > span:first-child {
+        display: block;
+        flex-grow: 1;
     }
-    &.disconnect {
-        padding: 0 !important;
-        .disconnect-text {
-            padding: 12px 16px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-        }
+
+    :disabled,
+    &[disabled] {
+        cursor: default;
+        opacity: 0.5;
     }
 `
+
+export const UserInfoMenuItem = styled(Menu.Item)`
+    padding: 0 16px !important;
+`
+
 export const MenuDivider = styled(Menu.Divider)`
     margin: 0;
 `
+
 export const WalletAddress = styled.div`
     margin-left: 13px;
     display: flex;

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -12,6 +12,9 @@ import toast from '~/utils/toast'
 import Popover from '~/shared/components/Popover'
 import PopoverItem from '~/shared/components/Popover/PopoverItem'
 import routes from '~/routes'
+import { useOperatorForWalletQuery } from '~/hooks/operators'
+import { saveOperator } from '~/utils'
+import { useMediaQuery } from '~/hooks'
 import { Avatarless, Name, Username } from './User'
 import {
     Avatar,
@@ -19,7 +22,6 @@ import {
     Menu,
     MenuDivider,
     MenuGrid,
-    MenuItem,
     MenuItemAvatarContainer,
     MOBILE_LG,
     Navbar,
@@ -33,6 +35,8 @@ import {
     SignedInUserMenu,
     StyledAccordionBody,
     StyledAccordionHeader,
+    TextMenuItem,
+    UserInfoMenuItem,
     UserInfoMobile,
     WalletAddress,
 } from './Nav.styles'
@@ -82,6 +86,12 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
     const ensName = useEns(account)
 
     const navigate = useNavigate()
+
+    const operatorQuery = useOperatorForWalletQuery(account)
+
+    const { data: operator = null, isFetching: isOperatorFetching } = operatorQuery
+
+    const isMobile = !useMediaQuery(`only screen and ${TABLET}`)
 
     return (
         <div {...props} data-testid={'desktop-nav'}>
@@ -168,7 +178,7 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
                                 toggle={<Avatar username={account} />}
                                 menu={
                                     <Menu>
-                                        <MenuItem className={'user-info'}>
+                                        <UserInfoMenuItem>
                                             <MenuItemAvatarContainer>
                                                 <Avatar username={account} />
                                                 <WalletAddress>
@@ -180,21 +190,59 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
                                                     <span>{truncate(account)}</span>
                                                 </WalletAddress>
                                             </MenuItemAvatarContainer>
-                                        </MenuItem>
+                                        </UserInfoMenuItem>
+                                        {isMobile && (
+                                            <>
+                                                <MenuDivider />
+                                                {operator ? (
+                                                    <TextMenuItem
+                                                        onClick={() => {
+                                                            navigate(
+                                                                routes.network.operator({
+                                                                    id: operator.id,
+                                                                }),
+                                                            )
+                                                        }}
+                                                    >
+                                                        <span>My Operator</span>
+                                                    </TextMenuItem>
+                                                ) : (
+                                                    <TextMenuItem
+                                                        disabled={isOperatorFetching}
+                                                        onClick={() => {
+                                                            if (isOperatorFetching) {
+                                                                return
+                                                            }
+
+                                                            saveOperator(undefined, {
+                                                                onDone(id) {
+                                                                    navigate(
+                                                                        routes.network.operator(
+                                                                            {
+                                                                                id,
+                                                                            },
+                                                                        ),
+                                                                    )
+                                                                },
+                                                            })
+                                                        }}
+                                                    >
+                                                        <span>Become an Operator</span>
+                                                    </TextMenuItem>
+                                                )}
+                                            </>
+                                        )}
                                         <MenuDivider />
-                                        <MenuItem
-                                            className="disconnect"
+                                        <TextMenuItem
                                             onClick={() => {
                                                 toast({
                                                     title: 'Use the "Lock" button in your wallet.',
                                                 })
                                             }}
                                         >
-                                            <div className={'disconnect-text'}>
-                                                <span>Disconnect</span>
-                                                <SvgIcon name={'disconnect'} />
-                                            </div>
-                                        </MenuItem>
+                                            <span>Disconnect</span>
+                                            <SvgIcon name="disconnect" />
+                                        </TextMenuItem>
                                     </Menu>
                                 }
                             />

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -121,6 +121,10 @@ export function useMaxUndelegationQueueDays() {
 export function useMediaQuery(query: string): boolean {
     const subscribe = useCallback(
         (cb: () => void) => {
+            if (typeof window.matchMedia !== 'function') {
+                return () => {}
+            }
+
             const matchMedia = window.matchMedia(query)
 
             matchMedia.addEventListener('change', cb)
@@ -132,5 +136,8 @@ export function useMediaQuery(query: string): boolean {
         [query],
     )
 
-    return useSyncExternalStore(subscribe, () => window.matchMedia(query).matches)
+    return useSyncExternalStore(
+        subscribe,
+        () => typeof window.matchMedia === 'function' && window.matchMedia(query).matches,
+    )
 }

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,5 +1,5 @@
 import { StreamrConfig } from '@streamr/network-contracts'
-import React, { useState } from 'react'
+import React, { useCallback, useState, useSyncExternalStore } from 'react'
 import { useEffect } from 'react'
 import { toaster } from 'toasterhea'
 import { getConfigValueFromChain } from '~/getters/getConfigValueFromChain'
@@ -116,4 +116,21 @@ export function useMaxUndelegationQueueDays() {
             ? maxQueueSeconds.div(60).div(60).div(24)
             : toBN(0)
     return maxQueueDays
+}
+
+export function useMediaQuery(query: string): boolean {
+    const subscribe = useCallback(
+        (cb: () => void) => {
+            const matchMedia = window.matchMedia(query)
+
+            matchMedia.addEventListener('change', cb)
+
+            return () => {
+                matchMedia.removeEventListener('change', cb)
+            }
+        },
+        [query],
+    )
+
+    return useSyncExternalStore(subscribe, () => window.matchMedia(query).matches)
 }

--- a/src/hooks/useInterceptHeartbeats.ts
+++ b/src/hooks/useInterceptHeartbeats.ts
@@ -28,7 +28,7 @@ export function useInterceptHeartbeats(operatorId: string | undefined) {
                 const {
                     parsedContent: { peerDescriptor },
                     messageId: { timestamp },
-                } = msg
+                } = msg as HeartbeatMessage
 
                 setHeartbeats((prev) => ({
                     ...prev,

--- a/src/shared/test/components/Nav/nav.test.tsx
+++ b/src/shared/test/components/Nav/nav.test.tsx
@@ -15,6 +15,24 @@ jest.mock('~/modals/ConnectModal', () => ({
     default: () => <></>,
 }))
 
+jest.mock('~/modals/OperatorModal', () => ({
+    __esModule: true,
+}))
+
+jest.mock('~/hooks/operators', () => {
+    const actual = jest.requireActual('~/hooks/operators')
+
+    return {
+        ...actual,
+        useOperatorForWalletQuery() {
+            return {
+                data: null,
+                isFetching: false,
+            }
+        },
+    }
+})
+
 jest.mock('~/routes', () => ({
     __esModule: true,
     default: {


### PR DESCRIPTION
I add "My Operator" and "Become an Operator" menu items to the profile menu on narrow-screened toys like mobile phones.

I also make a very superficial pass on the styling. Mobile breakpoints needs true love though!

---

In this PR our own quick `useMediaQuery` hook is born. 😉 