### PR TITLE
FRONT-1754: Keep expiration date icons visible on narrow screens

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -131,7 +131,7 @@ const Iconized = styled.div`
     align-items: center;
     display: grid;
     gap: 8px;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto 18px;
 
     ${TooltipIconWrap} svg {
         width: 18px;


### PR DESCRIPTION
I give the icons fixed widths so that they don't shrink.