### PR TITLE
FRONT-1756: Responsive operator/sponsorship modals

### DIFF
--- a/src/components/Abbr.tsx
+++ b/src/components/Abbr.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { abbr } from '~/utils'
+import { BNish } from '~/utils/bn'
+import { Tooltip } from '~/components/Tooltip'
+import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
+
+export function Abbr({ children }: { children: BNish }) {
+    const abbreviated = abbr(children)
+
+    const stringified = children.toString()
+
+    if (abbreviated === stringified) {
+        return (
+            <>
+                {stringified} <SponsorshipPaymentTokenName />
+            </>
+        )
+    }
+
+    return (
+        <Tooltip
+            inlineWrap
+            content={
+                <>
+                    {stringified} <SponsorshipPaymentTokenName />
+                </>
+            }
+        >
+            {abbreviated} <SponsorshipPaymentTokenName />
+        </Tooltip>
+    )
+}

--- a/src/components/Abbr.tsx
+++ b/src/components/Abbr.tsx
@@ -4,15 +4,22 @@ import { BNish } from '~/utils/bn'
 import { Tooltip } from '~/components/Tooltip'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 
-export function Abbr({ children }: { children: BNish }) {
+export function Abbr({ children, suffix }: { children: BNish; suffix?: string }) {
     const abbreviated = abbr(children)
 
     const stringified = children.toString()
 
+    const unit = (
+        <>
+            <SponsorshipPaymentTokenName />
+            {suffix}
+        </>
+    )
+
     if (abbreviated === stringified) {
         return (
             <>
-                {stringified} <SponsorshipPaymentTokenName />
+                {stringified} {unit}
             </>
         )
     }
@@ -22,11 +29,11 @@ export function Abbr({ children }: { children: BNish }) {
             inlineWrap
             content={
                 <>
-                    {stringified} <SponsorshipPaymentTokenName />
+                    {stringified} {unit}
                 </>
             }
         >
-            {abbreviated} <SponsorshipPaymentTokenName />
+            {abbreviated} {unit}
         </Tooltip>
     )
 }

--- a/src/components/Anchor.tsx
+++ b/src/components/Anchor.tsx
@@ -12,6 +12,7 @@ interface AnchorProps<T extends AnchorComponentProps = AnchorComponentProps>
     component: FC<T>
     componentProps: Omit<T, 'x' | 'y'>
     indicateOrigin?: boolean
+    inline?: boolean
     translate?: (rect: DOMRect | undefined) => [number, number]
 }
 
@@ -25,6 +26,7 @@ export function Anchor<T extends AnchorComponentProps = AnchorComponentProps>({
     component: Component,
     componentProps,
     children,
+    inline = false,
     ...props
 }: AnchorProps<T>) {
     const ref = useRef<HTMLDivElement>(null)
@@ -32,20 +34,18 @@ export function Anchor<T extends AnchorComponentProps = AnchorComponentProps>({
     const [x, y] = useBoundingClientRect(ref, (rect) => translate?.(rect) || [0, 0])
 
     return (
-        <>
-            <div {...props} ref={ref}>
-                {children}
-                {createPortal(
-                    <Component x={x} y={y} {...(componentProps as any)} />,
+        <Root {...props} ref={ref} $display={inline ? 'inline' : undefined}>
+            {children}
+            {createPortal(
+                <Component x={x} y={y} {...(componentProps as any)} />,
+                document.getElementById('hub-anchors')!,
+            )}
+            {indicateOrigin &&
+                createPortal(
+                    <OriginIndicator x={x} y={y} />,
                     document.getElementById('hub-anchors')!,
                 )}
-                {indicateOrigin &&
-                    createPortal(
-                        <OriginIndicator x={x} y={y} />,
-                        document.getElementById('hub-anchors')!,
-                    )}
-            </div>
-        </>
+        </Root>
     )
 }
 
@@ -92,3 +92,7 @@ export function useBoundingClientRect<T>(
         ),
     ) as T
 }
+
+const Root = styled.div<{ $display?: 'inline' }>`
+    display: ${({ $display }) => $display};
+`

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -5,9 +5,10 @@ import { Anchor, useBoundingClientRect } from './Anchor'
 interface Props {
     children: ReactNode
     content: ReactNode
+    inlineWrap?: boolean
 }
 
-export function Tooltip({ children, content }: Props) {
+export function Tooltip({ children, content, inlineWrap = false }: Props) {
     const [isOpen, toggle] = useState(false)
 
     useEffect(() => {
@@ -29,14 +30,15 @@ export function Tooltip({ children, content }: Props) {
 
     return (
         <Anchor
-            onMouseEnter={() => void toggle(true)}
-            onMouseLeave={() => void toggle(false)}
-            translate={(r) => (r ? [r.x + r.width / 2, r.y + window.scrollY] : [0, 0])}
             component={TooltipComponent}
             componentProps={{
                 children: content,
                 visible: isOpen,
             }}
+            inline={inlineWrap}
+            onMouseEnter={() => void toggle(true)}
+            onMouseLeave={() => void toggle(false)}
+            translate={(r) => (r ? [r.x + r.width / 2, r.y + window.scrollY] : [0, 0])}
         >
             {children}
         </Anchor>

--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -21,7 +21,7 @@ import {
     CreateSponsorshipForm,
     MinNumberOfOperatorsParser,
 } from '~/forms/createSponsorshipForm'
-import { useConfigValueFromChain } from '~/hooks'
+import { useConfigValueFromChain, useMediaQuery } from '~/hooks'
 import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { toDecimals } from '~/marketplace/utils/math'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
@@ -33,6 +33,7 @@ import { errorToast } from '~/utils/toast'
 import Toast from '~/shared/toasts/Toast'
 import { Layer } from '~/utils/Layer'
 import { SponsorshipDisclaimer } from '~/components/SponsorshipDisclaimer'
+import { Abbr } from '~/components/Abbr'
 
 interface ResolveProps {
     sponsorshipId: string
@@ -142,6 +143,8 @@ function CreateSponsorshipModal({
     const tooLongMinStakeDuration =
         !!maxPenaltyPeriod && minStakeDuration > maxPenaltyPeriod
 
+    const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
+
     return (
         <FormModal
             {...props}
@@ -245,7 +248,14 @@ function CreateSponsorshipModal({
                         <p>
                             Wallet balance:{' '}
                             <strong>
-                                {balanceProp.toString()} <SponsorshipPaymentTokenName />
+                                {limitedSpace ? (
+                                    <Abbr>{balanceProp}</Abbr>
+                                ) : (
+                                    <>
+                                        {balanceProp.toString()}{' '}
+                                        <SponsorshipPaymentTokenName />
+                                    </>
+                                )}
                             </strong>
                         </p>
                     </Hint>

--- a/src/modals/CreateSponsorshipModal.tsx
+++ b/src/modals/CreateSponsorshipModal.tsx
@@ -199,7 +199,7 @@ function CreateSponsorshipModal({
                     stream
                 </SectionHeadline>
                 <Section>
-                    <Label>Select a Stream</Label>
+                    <Label $wrap>Select a Stream</Label>
                     <StreamIdDropdown
                         autoFocus={!streamIdProp}
                         placeholder="Type to select a stream"
@@ -218,7 +218,7 @@ function CreateSponsorshipModal({
                 <GroupHeadline>Set Sponsorship parameters</GroupHeadline>
                 <Section>
                     <WingedLabelWrap>
-                        <Label>Initial amount to fund</Label>
+                        <Label $wrap>Initial amount to fund</Label>
                         {insufficientFunds && <ErrorLabel>Insufficient funds</ErrorLabel>}
                     </WingedLabelWrap>
                     <FieldWrap $invalid={insufficientFunds}>
@@ -251,7 +251,7 @@ function CreateSponsorshipModal({
                     </Hint>
                 </Section>
                 <Section>
-                    <Label>Payout rate*</Label>
+                    <Label $wrap>Payout rate*</Label>
                     <FieldWrap>
                         <TextInput
                             name="payoutRate"
@@ -281,7 +281,7 @@ function CreateSponsorshipModal({
                 </Section>
                 <Section>
                     <WingedLabelWrap>
-                        <Label>Minimum time operators must stay staked</Label>
+                        <Label $wrap>Minimum time operators must stay staked</Label>
                         <ErrorWrap>
                             {invalidMinStakeDuration && (
                                 <ErrorLabel>
@@ -318,7 +318,7 @@ function CreateSponsorshipModal({
                     </FieldWrap>
                 </Section>
                 <Section>
-                    <Label>Minimum number of operators to start payout</Label>
+                    <Label $wrap>Minimum number of operators to start payout</Label>
                     <FieldWrap
                         $invalid={invalidOperatorNumberRange || tooLowOperatorCount}
                     >
@@ -341,11 +341,13 @@ function CreateSponsorshipModal({
                                     : ''
                             }
                         />
-                        <TextAppendix>Operators</TextAppendix>
+                        <TextAppendix>
+                            <span>Operators</span>
+                        </TextAppendix>
                     </FieldWrap>
                 </Section>
                 <Section>
-                    <Label>Maximum number of operators</Label>
+                    <Label $wrap>Maximum number of operators</Label>
                     <FieldWrap $invalid={invalidOperatorNumberRange}>
                         <TextInput
                             name="maxNumberOfOperators"

--- a/src/modals/DelegateFundsModal.tsx
+++ b/src/modals/DelegateFundsModal.tsx
@@ -5,6 +5,8 @@ import FormModal, {
     FieldWrap,
     FormModalProps,
     Prop,
+    PropList,
+    PropValue,
     Section,
     SectionHeadline,
     TextAppendix,
@@ -17,11 +19,12 @@ import { Alert as PrestyledAlert } from '~/components/Alert'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { getSelfDelegatedAmount, getSelfDelegationFraction } from '~/getters'
 import { ParsedOperator } from '~/parsers/OperatorParser'
-import { useConfigValueFromChain } from '~/hooks'
+import { useConfigValueFromChain, useMediaQuery } from '~/hooks'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { delegateToOperator } from '~/services/operators'
 import { isTransactionRejection, waitForIndexedBlock } from '~/utils'
+import { Abbr } from '~/components/Abbr'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
     amount?: string
@@ -122,6 +125,8 @@ export default function DelegateFundsModal({
 
     const [busy, setBusy] = useState(false)
 
+    const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
+
     return (
         <FormModal
             {...props}
@@ -184,7 +189,7 @@ export default function DelegateFundsModal({
                         <SponsorshipPaymentTokenName />
                     </TextAppendix>
                 </FieldWrap>
-                <ul>
+                <PropList>
                     <li>
                         <Prop $invalid={insufficientFunds}>
                             {insufficientFunds ? (
@@ -193,21 +198,34 @@ export default function DelegateFundsModal({
                                 <>Your wallet balance</>
                             )}
                         </Prop>
-                        <div>
-                            {balance.toString()} <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{balance}</Abbr>
+                            ) : (
+                                <>
+                                    {balance.toString()} <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop>Operator</Prop>
-                        <div>{operator.id}</div>
+                        <PropValue>{operator.id}</PropValue>
                     </li>
                     <li>
                         <Prop>{totalLabel}</Prop>
-                        <div>
-                            {delegatedTotal.toString()} <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{delegatedTotal}</Abbr>
+                            ) : (
+                                <>
+                                    {delegatedTotal.toString()}{' '}
+                                    <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
-                </ul>
+                </PropList>
             </Section>
             <>
                 {tooLowCurrentSelfDelegation ? (

--- a/src/modals/EditStakeModal.tsx
+++ b/src/modals/EditStakeModal.tsx
@@ -8,6 +8,8 @@ import FormModal, {
     FieldWrap,
     FormModalProps,
     Prop,
+    PropList,
+    PropValue,
     Section,
     SectionHeadline,
     TextAppendix,
@@ -18,7 +20,7 @@ import Label from '~/shared/components/Ui/Label'
 import { BN, toBN } from '~/utils/bn'
 import { fromDecimals, toDecimals } from '~/marketplace/utils/math'
 import { Alert } from '~/components/Alert'
-import { useConfigValueFromChain } from '~/hooks'
+import { useConfigValueFromChain, useMediaQuery } from '~/hooks'
 import { ParsedOperator } from '~/parsers/OperatorParser'
 import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
@@ -32,6 +34,7 @@ import {
 } from '~/services/sponsorships'
 import { confirm } from '~/getters/confirm'
 import { Layer } from '~/utils/Layer'
+import { Abbr } from '~/components/Abbr'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
     leavePenaltyWei: BN
@@ -125,6 +128,10 @@ function EditStakeModal({
         : leavePenalty.plus(lockedStake)
 
     const dirty = sameBN(rawAmount || '0', currentAmount)
+
+    const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
+
+    const diff = fromDecimals(difference, decimals)
 
     return (
         <FormModal
@@ -235,7 +242,7 @@ function EditStakeModal({
             </SectionHeadline>
             <Section>
                 <WingedLabelWrap>
-                    <Label>Amount to stake</Label>
+                    <Label $wrap>Amount to stake</Label>
                     {rawAmount !== '' && !isFinalAmountWithinAcceptedRange && (
                         <ErrorLabel>
                             Minimum value is{' '}
@@ -262,19 +269,32 @@ function EditStakeModal({
                         <SponsorshipPaymentTokenName />
                     </TextAppendix>
                 </FieldWrap>
-                <ul>
+                <PropList>
                     <li>
                         <Prop>Current stake</Prop>
-                        <div>
-                            {currentAmount.toString()} <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{currentAmount}</Abbr>
+                            ) : (
+                                <>
+                                    {currentAmount.toString()}{' '}
+                                    <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop>Stake change</Prop>
-                        <div>
-                            {fromDecimals(difference, decimals).toString()}{' '}
-                            <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{diff}</Abbr>
+                            ) : (
+                                <>
+                                    {fromDecimals(difference, decimals).toString()}{' '}
+                                    <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop $invalid={insufficientFunds}>
@@ -284,12 +304,18 @@ function EditStakeModal({
                                 <>Available balance in Operator</>
                             )}
                         </Prop>
-                        <div>
-                            {fromDecimals(operatorBalance, decimals).toString()}{' '}
-                            <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{fromDecimals(operatorBalance, decimals)}</Abbr>
+                            ) : (
+                                <>
+                                    {fromDecimals(operatorBalance, decimals).toString()}{' '}
+                                    <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
-                </ul>
+                </PropList>
             </Section>
             {finalAmount.isEqualTo(0) && leavePenalty.isGreaterThan(0) && (
                 <StyledAlert type="error" title="Your stake will be slashed">

--- a/src/modals/EditStakeModal.tsx
+++ b/src/modals/EditStakeModal.tsx
@@ -290,8 +290,7 @@ function EditStakeModal({
                                 <Abbr>{diff}</Abbr>
                             ) : (
                                 <>
-                                    {fromDecimals(difference, decimals).toString()}{' '}
-                                    <SponsorshipPaymentTokenName />
+                                    {diff.toString()} <SponsorshipPaymentTokenName />
                                 </>
                             )}
                         </PropValue>

--- a/src/modals/FormModal.tsx
+++ b/src/modals/FormModal.tsx
@@ -175,25 +175,6 @@ export const Section = styled.div`
         line-height: 20px;
     }
 
-    > ul {
-        background: ${COLORS.secondaryLight};
-        font-size: 14px;
-        list-style: none;
-        margin: 16px 0 0;
-        padding: 16px;
-        border-radius: 8px;
-        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02);
-
-        li {
-            display: flex;
-            align-items: center;
-        }
-
-        li + li {
-            margin-top: 16px;
-        }
-    }
-
     & + & {
         margin-top: 16px;
     }
@@ -222,9 +203,6 @@ export const PropValue = styled.div`
     white-space: nowrap;
 `
 
-/**
- * @todo Same as `Section > ul …`.
- */
 export const PropList = styled.ul`
     background: ${COLORS.secondaryLight};
     font-size: 14px;

--- a/src/modals/FormModal.tsx
+++ b/src/modals/FormModal.tsx
@@ -266,6 +266,7 @@ export const WingedLabelWrap = styled.div`
 
     ${Label} {
         flex-grow: 1;
+        min-width: 0;
     }
 
     ${Label} + ${Label} {
@@ -291,6 +292,7 @@ export const TextInput = styled.input`
     padding: 0 18px;
     flex-grow: 1;
     outline: 0;
+    min-width: 48px;
 
     ::-webkit-outer-spin-button,
     ::-webkit-inner-spin-button {

--- a/src/modals/FormModal.tsx
+++ b/src/modals/FormModal.tsx
@@ -200,19 +200,49 @@ export const Section = styled.div`
 `
 
 export const Prop = styled.em<{ $invalid?: boolean }>`
-    opacity: 0.7;
     color: ${COLORS.primaryLight};
-    flex-grow: 1;
     display: block;
-    font-style: normal;
+    flex-grow: 1;
     font-size: 12px;
+    font-style: normal;
     font-weight: ${MEDIUM};
+    opacity: 0.7;
 
     ${({ $invalid = false }) =>
         $invalid &&
         css`
             color: ${COLORS.error};
         `}
+`
+
+export const PropValue = styled.div`
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`
+
+/**
+ * @todo Same as `Section > ul …`.
+ */
+export const PropList = styled.ul`
+    background: ${COLORS.secondaryLight};
+    font-size: 14px;
+    list-style: none;
+    margin: 16px 0 0;
+    padding: 16px;
+    border-radius: 8px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02);
+
+    li {
+        align-items: center;
+        display: flex;
+        gap: 8px;
+    }
+
+    li + li {
+        margin-top: 16px;
+    }
 `
 
 export const GroupHeadline = styled.h2`

--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -6,6 +6,8 @@ import FormModal, {
     FieldWrap,
     FormModalProps,
     Prop,
+    PropList,
+    PropValue,
     Section,
     SectionHeadline,
     TextAppendix,
@@ -22,6 +24,8 @@ import { toDecimals } from '~/marketplace/utils/math'
 import { fundSponsorship } from '~/services/sponsorships'
 import { isTransactionRejection, waitForIndexedBlock } from '~/utils'
 import { SponsorshipDisclaimer } from '~/components/SponsorshipDisclaimer'
+import { useMediaQuery } from '~/hooks'
+import { Abbr } from '~/components/Abbr'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
     balance: BN
@@ -117,6 +121,8 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
 
     const dirty = rawAmount !== ''
 
+    const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
+
     return (
         <FormModal
             {...props}
@@ -156,7 +162,7 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
                 extend the Sponsorship
             </SectionHeadline>
             <Section>
-                <Label>Amount to sponsor</Label>
+                <Label $wrap>Amount to sponsor</Label>
                 <FieldWrap $invalid={insufficientFunds}>
                     <TextInput
                         name="amount"
@@ -173,7 +179,7 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
                         <SponsorshipPaymentTokenName />
                     </TextAppendix>
                 </FieldWrap>
-                <ul>
+                <PropList>
                     <li>
                         <Prop $invalid={insufficientFunds}>
                             {insufficientFunds ? (
@@ -182,27 +188,43 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
                                 <>Your wallet balance</>
                             )}
                         </Prop>
-                        <div>
-                            {balance.toString()} <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{balance}</Abbr>
+                            ) : (
+                                <>
+                                    {balance.toString()} <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop>Sponsorship extended by</Prop>
-                        <div>{extensionText}</div>
+                        <PropValue>{extensionText}</PropValue>
                     </li>
                     <li>
                         <Prop>New end date</Prop>
-                        <div>{moment(endDate).format('YYYY-MM-DD')}</div>
+                        <PropValue>
+                            {moment(endDate).format(
+                                limitedSpace ? 'YY-MM-DD' : 'YYYY-MM-DD',
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop>Rate</Prop>
-                        <div>
-                            {sponsorship.payoutPerDay.toString()}{' '}
-                            <SponsorshipPaymentTokenName />
-                            /day
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr suffix="/day">{sponsorship.payoutPerDay}</Abbr>
+                            ) : (
+                                <>
+                                    {sponsorship.payoutPerDay.toString()}{' '}
+                                    <SponsorshipPaymentTokenName />
+                                    /day
+                                </>
+                            )}
+                        </PropValue>
                     </li>
-                </ul>
+                </PropList>
             </Section>
             <SponsorshipDisclaimer
                 sponsorship={sponsorship}

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -9,6 +9,8 @@ import FormModal, {
     FieldWrap,
     FormModalProps,
     Prop,
+    PropList,
+    PropValue,
     Section,
     SectionHeadline,
     TextAppendix,
@@ -23,7 +25,7 @@ import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS } from '~/shared/utils/styled'
 import useOperatorLiveNodes from '~/hooks/useOperatorLiveNodes'
 import { fromDecimals, toDecimals } from '~/marketplace/utils/math'
-import { useConfigValueFromChain } from '~/hooks'
+import { useConfigValueFromChain, useMediaQuery } from '~/hooks'
 import { useInterceptHeartbeats } from '~/hooks/useInterceptHeartbeats'
 import { ParsedOperator } from '~/parsers/OperatorParser'
 import { ParsedSponsorship } from '~/parsers/SponsorshipParser'
@@ -34,6 +36,8 @@ import { errorToast } from '~/utils/toast'
 import Toast from '~/shared/toasts/Toast'
 import { Layer } from '~/utils/Layer'
 import { getSelfDelegationFraction } from '~/getters'
+import { Abbr } from '~/components/Abbr'
+import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
     amount?: string
@@ -129,6 +133,8 @@ function JoinSponsorshipModal({
 
     const { copy } = useCopy()
 
+    const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
+
     return (
         <FormModal
             {...props}
@@ -181,7 +187,7 @@ function JoinSponsorshipModal({
                 Sponsorship
             </SectionHeadline>
             <Section>
-                <Label>Sponsorship Stream ID</Label>
+                <Label $wrap>Sponsorship Stream ID</Label>
                 <FieldWrap $grayedOut>
                     <TextInput defaultValue={streamId} readOnly />
                     {!!streamId && (
@@ -193,7 +199,7 @@ function JoinSponsorshipModal({
                     )}
                 </FieldWrap>
                 <StyledLabelWrap>
-                    <Label>Amount to stake</Label>
+                    <Label $wrap>Amount to stake</Label>
                     {rawAmount !== '' && !isAboveMinimumStake && (
                         <ErrorLabel>
                             Minimum value is{' '}
@@ -216,13 +222,13 @@ function JoinSponsorshipModal({
                     />
                     <TextAppendix>{tokenSymbol}</TextAppendix>
                 </FieldWrap>
-                <ul>
+                <PropList>
                     <li>
                         <Prop>Minimum stake duration</Prop>
-                        <div>
+                        <PropValue>
                             {minimumStakingDays.toFixed(0)} day
                             {minimumStakingDays !== 1 && 's'}
-                        </div>
+                        </PropValue>
                     </li>
                     <li>
                         <Prop $invalid={insufficientFunds}>
@@ -232,16 +238,22 @@ function JoinSponsorshipModal({
                                 <>Available balance in Operator</>
                             )}
                         </Prop>
-                        <div>
-                            {fromDecimals(operatorBalance, decimals).toString()}{' '}
-                            {tokenSymbol}
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{fromDecimals(operatorBalance, decimals)}</Abbr>
+                            ) : (
+                                <>
+                                    {fromDecimals(operatorBalance, decimals).toString()}{' '}
+                                    <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop>Operator</Prop>
-                        <div>{operatorId}</div>
+                        <PropValue>{operatorId}</PropValue>
                     </li>
-                </ul>
+                </PropList>
             </Section>
             {isBelowSelfFundingLimit && (
                 <StyledAlert type="error" title="Low self-funding">

--- a/src/modals/OperatorModal.tsx
+++ b/src/modals/OperatorModal.tsx
@@ -224,11 +224,7 @@ function OperatorModal({ onResolve, onReject, operator, ...props }: Props) {
             </SectionHeadline>
             <Section>
                 <WingedLabelWrap>
-                    <Label>
-                        <LabelInner>
-                            <span>Owner&apos;s cut percentage*</span>
-                        </LabelInner>
-                    </Label>
+                    <Label $wrap>Owner&apos;s cut percentage*</Label>
                     {errors?.cut && <ErrorLabel>{errors.cut}</ErrorLabel>}
                 </WingedLabelWrap>
                 <FieldWrap $invalid={!!errors?.cut} $grayedOut={readonlyCut}>
@@ -277,11 +273,7 @@ function OperatorModal({ onResolve, onReject, operator, ...props }: Props) {
             </SectionHeadline>
             <Section>
                 <WingedLabelWrap>
-                    <Label>
-                        <LabelInner>
-                            <span>Node redundancy factor*</span>
-                        </LabelInner>
-                    </Label>
+                    <Label $wrap>Node redundancy factor*</Label>
                     {errors?.redundancyFactor && (
                         <ErrorLabel>{errors.redundancyFactor}</ErrorLabel>
                     )}
@@ -309,11 +301,7 @@ function OperatorModal({ onResolve, onReject, operator, ...props }: Props) {
                 <SectionHeadline>About Operator</SectionHeadline>
                 <Section>
                     <WingedLabelWrap>
-                        <Label>
-                            <LabelInner>
-                                <span>Display name*</span>
-                            </LabelInner>
-                        </Label>
+                        <Label $wrap>Display name*</Label>
                         {errors?.name && <ErrorLabel>{errors.name}</ErrorLabel>}
                     </WingedLabelWrap>
                     <FieldWrap $invalid={!!errors?.name}>
@@ -333,11 +321,7 @@ function OperatorModal({ onResolve, onReject, operator, ...props }: Props) {
                     </FieldWrap>
                     <AboutOperatorField>
                         <WingedLabelWrap>
-                            <Label>
-                                <LabelInner>
-                                    <span>Description</span>
-                                </LabelInner>
-                            </Label>
+                            <Label $wrap>Description</Label>
                             {errors?.description && (
                                 <ErrorLabel>Description is too long</ErrorLabel>
                             )}
@@ -362,11 +346,7 @@ function OperatorModal({ onResolve, onReject, operator, ...props }: Props) {
                         </FieldWrap>
                     </AboutOperatorField>
                     <AboutOperatorField>
-                        <Label>
-                            <LabelInner>
-                                <span>Operator Avatar</span>
-                            </LabelInner>
-                        </Label>
+                        <Label $wrap>Operator Avatar</Label>
                         <FieldWrap>
                             <AvatarField>
                                 <AvatarDisplayContainer>
@@ -436,11 +416,6 @@ function OperatorModal({ onResolve, onReject, operator, ...props }: Props) {
 }
 
 export const operatorModal = toaster(OperatorModal, Layer.Modal)
-
-const LabelInner = styled.div`
-    align-items: center;
-    display: flex;
-`
 
 const AboutOperator = styled.div`
     margin-top: 40px;

--- a/src/modals/UndelegateFundsModal.tsx
+++ b/src/modals/UndelegateFundsModal.tsx
@@ -6,6 +6,8 @@ import FormModal, {
     FieldWrap,
     FormModalProps,
     Prop,
+    PropList,
+    PropValue,
     Section,
     SectionHeadline,
     TextAppendix,
@@ -15,13 +17,18 @@ import Label from '~/shared/components/Ui/Label'
 import { COLORS } from '~/shared/utils/styled'
 import { BN, toBN } from '~/utils/bn'
 import { fromDecimals, toDecimals } from '~/marketplace/utils/math'
-import { useConfigValueFromChain, useMaxUndelegationQueueDays } from '~/hooks'
+import {
+    useConfigValueFromChain,
+    useMaxUndelegationQueueDays,
+    useMediaQuery,
+} from '~/hooks'
 import { ParsedOperator } from '~/parsers/OperatorParser'
 import { useSponsorshipTokenInfo } from '~/hooks/sponsorships'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentTokenName'
 import { undelegateFromOperator } from '~/services/operators'
 import { isTransactionRejection, waitForIndexedBlock } from '~/utils'
+import { Abbr } from '~/components/Abbr'
 
 interface Props extends Pick<FormModalProps, 'onReject'> {
     balance: BN
@@ -97,6 +104,8 @@ export default function UndelegateFundsModal({
 
     const [busy, setBusy] = useState(false)
 
+    const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
+
     return (
         <FormModal
             {...props}
@@ -142,7 +151,7 @@ export default function UndelegateFundsModal({
                 {subtitlePartial}
             </SectionHeadline>
             <Section>
-                <Label>{amountLabel}</Label>
+                <Label $wrap>{amountLabel}</Label>
                 <FieldWrap $top={true}>
                     <TextInput
                         name="amount"
@@ -161,31 +170,50 @@ export default function UndelegateFundsModal({
                 </FieldWrap>
                 <FieldWrap $bottom={true} $padded={true}>
                     <Prop>
-                        {totalLabel}: {delegatedTotal.toString()}{' '}
-                        <SponsorshipPaymentTokenName />
+                        {totalLabel}:{' '}
+                        {limitedSpace ? (
+                            <Abbr>{delegatedTotal}</Abbr>
+                        ) : (
+                            <>
+                                {delegatedTotal.toString()}{' '}
+                                <SponsorshipPaymentTokenName />
+                            </>
+                        )}
                     </Prop>
                     <LinkButton onClick={() => setRawAmount(delegatedTotal.toString())}>
                         Max
                     </LinkButton>
                 </FieldWrap>
-                <ul>
+                <PropList>
                     <li>
                         <Prop>Your wallet balance</Prop>
-                        <div>
-                            {balance.toString()} <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{balance}</Abbr>
+                            ) : (
+                                <>
+                                    {balance.toString()} <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
                     <li>
                         <Prop>Operator</Prop>
-                        <div>{operator.id}</div>
+                        <PropValue>{operator.id}</PropValue>
                     </li>
                     <li>
                         <Prop>Available balance in Operator</Prop>
-                        <div>
-                            {freeFunds.toString()} <SponsorshipPaymentTokenName />
-                        </div>
+                        <PropValue>
+                            {limitedSpace ? (
+                                <Abbr>{freeFunds}</Abbr>
+                            ) : (
+                                <>
+                                    {freeFunds.toString()} <SponsorshipPaymentTokenName />
+                                </>
+                            )}
+                        </PropValue>
                     </li>
-                </ul>
+                </PropList>
             </Section>
             <Footer>
                 {toBN(rawAmount).isGreaterThan(0) &&

--- a/src/shared/components/Ui/Label.tsx
+++ b/src/shared/components/Ui/Label.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLProps } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import * as Colors from '~/shared/components/Ui/StateColors'
 import { MEDIUM } from '~/shared/utils/styled'
 
@@ -16,7 +16,7 @@ function UnstyledLabel({ children, keepSpace = false, ...props }: Props) {
     )
 }
 
-const Label = styled(UnstyledLabel)<{ state?: string }>`
+const Label = styled(UnstyledLabel)<{ state?: string; $wrap?: boolean }>`
     color: ${({ state }) =>
         (Colors as { [key: string]: string })[state] || Colors.DEFAULT};
     display: block;
@@ -26,6 +26,11 @@ const Label = styled(UnstyledLabel)<{ state?: string }>`
     margin: 0 0 8px;
     transition: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
     transition-property: color, transform;
-    white-space: nowrap;
+
+    ${({ $wrap = false }) =>
+        !$wrap &&
+        css`
+            white-space: nowrap;
+        `}
 `
 export default Label


### PR DESCRIPTION
In this PR I address a couple of problems:
- fields with high min-width that push the appendix outside of the field wrap (the white area),
- labels that don't wrap when the space is tight,
- long big numbers that don't wrap or get truncated,
- wallet addresses that don't wrap or get truncated.

