### PR TITLE
FRONT-1744: Add "MAX" buttons to selected amount fields

### DIFF
--- a/src/components/Abbr.tsx
+++ b/src/components/Abbr.tsx
@@ -19,7 +19,7 @@ export function Abbr({ children, suffix }: { children: BNish; suffix?: string })
     if (abbreviated === stringified) {
         return (
             <>
-                {stringified} {unit}
+                {stringified}&nbsp;{unit}
             </>
         )
     }
@@ -29,11 +29,11 @@ export function Abbr({ children, suffix }: { children: BNish; suffix?: string })
             inlineWrap
             content={
                 <>
-                    {stringified} {unit}
+                    {stringified}&nbsp;{unit}
                 </>
             }
         >
-            {abbreviated} {unit}
+            {abbreviated}&nbsp;{unit}
         </Tooltip>
     )
 }

--- a/src/modals/DelegateFundsModal.tsx
+++ b/src/modals/DelegateFundsModal.tsx
@@ -4,6 +4,7 @@ import { RejectionReason, isRejectionReason } from '~/modals/BaseModal'
 import FormModal, {
     FieldWrap,
     FormModalProps,
+    MaxButton,
     Prop,
     PropList,
     PropValue,
@@ -184,6 +185,11 @@ export default function DelegateFundsModal({
                         min={0}
                         step="any"
                         value={rawAmount}
+                    />
+                    <MaxButton
+                        onClick={() => {
+                            setRawAmount(balance.toString())
+                        }}
                     />
                     <TextAppendix>
                         <SponsorshipPaymentTokenName />

--- a/src/modals/EditStakeModal.tsx
+++ b/src/modals/EditStakeModal.tsx
@@ -7,6 +7,7 @@ import FormModal, {
     ErrorLabel,
     FieldWrap,
     FormModalProps,
+    MaxButton,
     Prop,
     PropList,
     PropValue,
@@ -132,6 +133,8 @@ function EditStakeModal({
     const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
 
     const diff = fromDecimals(difference, decimals)
+
+    const availableBalance = fromDecimals(operatorBalance, decimals)
 
     return (
         <FormModal
@@ -265,6 +268,11 @@ function EditStakeModal({
                         step="any"
                         value={rawAmount}
                     />
+                    <MaxButton
+                        onClick={() => {
+                            setRawAmount(availableBalance.plus(currentAmount).toString())
+                        }}
+                    />
                     <TextAppendix>
                         <SponsorshipPaymentTokenName />
                     </TextAppendix>
@@ -305,10 +313,10 @@ function EditStakeModal({
                         </Prop>
                         <PropValue>
                             {limitedSpace ? (
-                                <Abbr>{fromDecimals(operatorBalance, decimals)}</Abbr>
+                                <Abbr>{availableBalance}</Abbr>
                             ) : (
                                 <>
-                                    {fromDecimals(operatorBalance, decimals).toString()}{' '}
+                                    {availableBalance.toString()}{' '}
                                     <SponsorshipPaymentTokenName />
                                 </>
                             )}

--- a/src/modals/FormModal.tsx
+++ b/src/modals/FormModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ComponentProps, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import { COLORS, MEDIUM, REGULAR, SANS, TABLET } from '~/shared/utils/styled'
 import Buttons, { ButtonActions } from '~/shared/components/Buttons'
@@ -422,4 +422,28 @@ export const CopyButtonWrapAppendix = styled(Appendix)`
 export const IconWrapAppendix = styled(Appendix)`
     color: ${COLORS.primaryDisabled};
     padding-right: 10px;
+`
+
+function getMaxButtonAttrs(): ComponentProps<'button'> {
+    return {
+        type: 'button',
+        children: 'MAX',
+    }
+}
+
+export const MaxButton = styled.button.attrs(getMaxButtonAttrs)`
+    appearance: none;
+    background: #f8f8f8;
+    border: 0;
+    border-radius: 4px;
+    color: #0324ff;
+    flex: 0;
+    font-size: 12px;
+    font-weight: ${MEDIUM};
+    line-height: normal;
+    padding: 2px 4px;
+
+    & + * {
+        margin-left: 12px;
+    }
 `

--- a/src/modals/FundSponsorshipModal.tsx
+++ b/src/modals/FundSponsorshipModal.tsx
@@ -5,6 +5,7 @@ import { RejectionReason, isRejectionReason } from '~/modals/BaseModal'
 import FormModal, {
     FieldWrap,
     FormModalProps,
+    MaxButton,
     Prop,
     PropList,
     PropValue,
@@ -174,6 +175,11 @@ function FundSponsorshipModal({ balance, onResolve, sponsorship, ...props }: Pro
                         min={0}
                         step="any"
                         value={rawAmount}
+                    />
+                    <MaxButton
+                        onClick={() => {
+                            setRawAmount(balance.toString())
+                        }}
                     />
                     <TextAppendix>
                         <SponsorshipPaymentTokenName />

--- a/src/modals/JoinSponsorshipModal.tsx
+++ b/src/modals/JoinSponsorshipModal.tsx
@@ -8,6 +8,7 @@ import FormModal, {
     ErrorLabel,
     FieldWrap,
     FormModalProps,
+    MaxButton,
     Prop,
     PropList,
     PropValue,
@@ -135,6 +136,8 @@ function JoinSponsorshipModal({
 
     const limitedSpace = useMediaQuery('screen and (max-width: 460px)')
 
+    const availableBalance = fromDecimals(operatorBalance, decimals)
+
     return (
         <FormModal
             {...props}
@@ -220,6 +223,11 @@ function JoinSponsorshipModal({
                         step="any"
                         value={rawAmount}
                     />
+                    <MaxButton
+                        onClick={() => {
+                            setRawAmount(availableBalance.toString())
+                        }}
+                    />
                     <TextAppendix>{tokenSymbol}</TextAppendix>
                 </FieldWrap>
                 <PropList>
@@ -240,10 +248,10 @@ function JoinSponsorshipModal({
                         </Prop>
                         <PropValue>
                             {limitedSpace ? (
-                                <Abbr>{fromDecimals(operatorBalance, decimals)}</Abbr>
+                                <Abbr>{availableBalance}</Abbr>
                             ) : (
                                 <>
-                                    {fromDecimals(operatorBalance, decimals).toString()}{' '}
+                                    {availableBalance.toString()}{' '}
                                     <SponsorshipPaymentTokenName />
                                 </>
                             )}

--- a/src/modals/UndelegateFundsModal.tsx
+++ b/src/modals/UndelegateFundsModal.tsx
@@ -164,7 +164,11 @@ export default function UndelegateFundsModal({
                         step="any"
                         value={rawAmount}
                     />
-                    <MaxButton onClick={() => setRawAmount(delegatedTotal.toString())} />
+                    <MaxButton
+                        onClick={() => {
+                            setRawAmount(delegatedTotal.toString())
+                        }}
+                    />
                     <TextAppendix>
                         <SponsorshipPaymentTokenName />
                     </TextAppendix>

--- a/src/modals/UndelegateFundsModal.tsx
+++ b/src/modals/UndelegateFundsModal.tsx
@@ -5,6 +5,7 @@ import { RejectionReason, isRejectionReason } from '~/modals/BaseModal'
 import FormModal, {
     FieldWrap,
     FormModalProps,
+    MaxButton,
     Prop,
     PropList,
     PropValue,
@@ -14,7 +15,6 @@ import FormModal, {
     TextInput,
 } from '~/modals/FormModal'
 import Label from '~/shared/components/Ui/Label'
-import { COLORS } from '~/shared/utils/styled'
 import { BN, toBN } from '~/utils/bn'
 import { fromDecimals, toDecimals } from '~/marketplace/utils/math'
 import {
@@ -164,6 +164,7 @@ export default function UndelegateFundsModal({
                         step="any"
                         value={rawAmount}
                     />
+                    <MaxButton onClick={() => setRawAmount(delegatedTotal.toString())} />
                     <TextAppendix>
                         <SponsorshipPaymentTokenName />
                     </TextAppendix>
@@ -180,9 +181,6 @@ export default function UndelegateFundsModal({
                             </>
                         )}
                     </Prop>
-                    <LinkButton onClick={() => setRawAmount(delegatedTotal.toString())}>
-                        Max
-                    </LinkButton>
                 </FieldWrap>
                 <PropList>
                     <li>
@@ -263,11 +261,6 @@ export default function UndelegateFundsModal({
         </FormModal>
     )
 }
-
-const LinkButton = styled.a`
-    cursor: pointer;
-    color: ${COLORS.link};
-`
 
 const Footer = styled.div`
     display: grid;

--- a/stories/Spinner.stories.tsx
+++ b/stories/Spinner.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
 import Spinner from '~/components/Spinner'
-import { COLORS } from '~/shared/utils/styled'
 
 export const SpinnerSmall = () => <Spinner />
 SpinnerSmall.story = {


### PR DESCRIPTION
Here I add a "convenience" button that populates the amount with the available wallet or operator balance. I do it for amount fields in the following modal dialog boxes:
- Delegate funds to O
- Undelegate funds from O
- Join S as O
- Edit stake
- Sponsor S

Onwards!