### PR TITLE
[FRONT-1741] Chart y-axis scaling

### DIFF
--- a/src/pages/NetworkOverviewPage.tsx
+++ b/src/pages/NetworkOverviewPage.tsx
@@ -69,7 +69,7 @@ function MyOperatorSummary() {
 
     const { value = toBN(0), numOfDelegators = 0, numOfSponsorships = 0 } = stats || {}
 
-    const [chartPeriod, setChartPeriod] = useState<ChartPeriod>(ChartPeriod.SevenDays)
+    const [chartPeriod, setChartPeriod] = useState<ChartPeriod>(ChartPeriod.ThreeMonths)
 
     const [chartId, setChartId] = useState<'stake' | 'earnings'>('stake')
 
@@ -244,7 +244,7 @@ function MyDelegationsSummary() {
 
     const apy = minApy === maxApy ? [minApy] : [minApy, maxApy]
 
-    const [chartPeriod, setChartPeriod] = useState<ChartPeriod>(ChartPeriod.SevenDays)
+    const [chartPeriod, setChartPeriod] = useState<ChartPeriod>(ChartPeriod.ThreeMonths)
     const [chartDataSource, setChartDataSource] = useState<
         'currentValue' | 'cumulativeEarnings'
     >('currentValue')

--- a/src/pages/SingleOperatorPage.tsx
+++ b/src/pages/SingleOperatorPage.tsx
@@ -95,7 +95,7 @@ export const SingleOperatorPage = () => {
     >('totalValue')
 
     const [selectedPeriod, setSelectedPeriod] = useState<ChartPeriod>(
-        ChartPeriod.SevenDays,
+        ChartPeriod.ThreeMonths,
     )
 
     const chartQuery = useQuery({

--- a/src/pages/SingleSponsorshipPage.tsx
+++ b/src/pages/SingleSponsorshipPage.tsx
@@ -70,7 +70,7 @@ export const SingleSponsorshipPage = () => {
     >('amountStaked')
 
     const [selectedPeriod, setSelectedPeriod] = useState<ChartPeriod>(
-        ChartPeriod.SevenDays,
+        ChartPeriod.ThreeMonths,
     )
 
     const chartQuery = useSponsorshipDailyBucketsQuery({

--- a/src/shared/components/TimeSeriesGraph/index.tsx
+++ b/src/shared/components/TimeSeriesGraph/index.tsx
@@ -107,6 +107,7 @@ const TimeSeriesGraph = ({
                             interval="preserveStartEnd"
                         />
                         <YAxis
+                            domain={['dataMin', 'dataMax']}
                             dataKey="y"
                             orientation="right"
                             tickMargin={10}


### PR DESCRIPTION
Chart y-axis is now scaled based on data values. The default domain is [0, 'auto'] and that was causing often uninformative charts. I also changed default chart period to be 3 months.