### PR TITLE
fix ci (v2): use brubeck docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1-brubeck nginx"
       - name: Run Jest Tests
         run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs npx jest --verbose --useStderr --forceExit --coverage=false --logHeapUsage --runInBand
         env:
@@ -113,7 +113,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1 nginx"
+          services-to-start: "mysql cassandra parity-node0 parity-sidechain-node0 broker-node-storage-1-brubeck nginx"
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
I had to implement this fix differently. The Brubeck specific broker images are now suffixed with `-brubeck`.