### PR TITLE
Simplifications and tweaks

### DIFF
--- a/src/components/ProjectProperty.tsx
+++ b/src/components/ProjectProperty.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS } from '~/shared/utils/styled'
 import EnterIcon from '~/shared/assets/icons/enter.svg'
-import { useSetProjectDraftErrors } from '~/stores/projectDraft'
+import { ProjectDraft } from '~/stores/projectDraft'
 
 export default function ProjectProperty({
     disabled = false,
@@ -31,7 +31,7 @@ export default function ProjectProperty({
         setValue(valueProp)
     }, [valueProp])
 
-    const setErrors = useSetProjectDraftErrors()
+    const setErrors = ProjectDraft.useSetDraftErrors()
 
     return (
         <Root

--- a/src/hooks/streams.tsx
+++ b/src/hooks/streams.tsx
@@ -392,7 +392,7 @@ export function useGlobalStreamStatsQuery() {
             const client = getIndexerClient(chainId)
 
             if (!client) {
-                return
+                return null
             }
 
             try {
@@ -412,6 +412,8 @@ export function useGlobalStreamStatsQuery() {
             } catch (e) {
                 console.warn('Fetching global streams stats failed', e)
             }
+
+            return null
         },
     })
 }

--- a/src/pages/ProjectPage/DataUnionFee.tsx
+++ b/src/pages/ProjectPage/DataUnionFee.tsx
@@ -2,18 +2,18 @@ import React from 'react'
 import styled from 'styled-components'
 import { getEmptyParsedProject } from '~/parsers/ProjectParser'
 import TextField from '~/shared/components/Ui/Text/StyledInput'
-import { useProject, useUpdateProject } from '~/stores/projectDraft'
+import { ProjectDraft } from '~/stores/projectDraft'
 import { ProjectType } from '~/shared/types'
 import { COLORS } from '~/shared/utils/styled'
 
 export default function DataUnionFee({ disabled = false }: { disabled?: boolean }) {
-    const update = useUpdateProject()
+    const update = ProjectDraft.useUpdateEntity()
 
     const emptyProject = getEmptyParsedProject({ type: ProjectType.OpenData })
 
-    const project = useProject({ hot: true }) || emptyProject
+    const project = ProjectDraft.useEntity({ hot: true }) || emptyProject
 
-    const coldProject = useProject() || emptyProject
+    const coldProject = ProjectDraft.useEntity() || emptyProject
 
     const isDataUnion = project.type === ProjectType.DataUnion
 

--- a/src/pages/ProjectPage/DataUnionPayment.tsx
+++ b/src/pages/ProjectPage/DataUnionPayment.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { useProject } from '~/stores/projectDraft'
+import { ProjectDraft } from '~/stores/projectDraft'
 import { SalePoint } from '~/shared/types'
 
 export default function DataUnionPayment({
@@ -7,7 +7,7 @@ export default function DataUnionPayment({
 }: {
     children?: (salePoint: SalePoint | undefined) => ReactNode
 }) {
-    const { salePoints = {} } = useProject({ hot: true }) || {}
+    const { salePoints = {} } = ProjectDraft.useEntity({ hot: true }) || {}
 
     const salePoint = Object.values(salePoints).find((salePoint) => salePoint?.enabled)
 

--- a/src/pages/ProjectPage/EditorHero.tsx
+++ b/src/pages/ProjectPage/EditorHero.tsx
@@ -1,14 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { toaster } from 'toasterhea'
-import {
-    useIsProjectDraftBusy,
-    usePersistProjectCallback,
-    useProject,
-    useProjectDraft,
-    useSetProjectDraftErrors,
-    useUpdateProject,
-} from '~/stores/projectDraft'
+import { ProjectDraft, usePersistProjectCallback } from '~/stores/projectDraft'
 import { COLORS } from '~/shared/utils/styled'
 import RichTextEditor from '~/components/RichTextEditor'
 import DetailDropdown, {
@@ -28,20 +21,20 @@ const cropModal = toaster(CropImageModal, Layer.Modal)
 
 export default function EditorHero() {
     const { creator, contact, name, description, imageUrl } =
-        useProject({ hot: true }) ||
+        ProjectDraft.useEntity({ hot: true }) ||
         getEmptyParsedProject({
             type: ProjectType.OpenData,
         })
 
     const [newImageUrl, setNewImageUrl] = useState<string>()
 
-    const update = useUpdateProject()
+    const update = ProjectDraft.useUpdateEntity()
 
-    const errors = useProjectDraft()?.errors || {}
+    const errors = ProjectDraft.useDraft()?.errors || {}
 
-    const setErrors = useSetProjectDraftErrors()
+    const setErrors = ProjectDraft.useSetDraftErrors()
 
-    const busy = useIsProjectDraftBusy()
+    const busy = ProjectDraft.useIsDraftBusy()
 
     const imageAbortControllerRef = useRef<AbortController>()
 

--- a/src/pages/ProjectPage/EditorNav.tsx
+++ b/src/pages/ProjectPage/EditorNav.tsx
@@ -6,12 +6,7 @@ import { LogoLink, Navbar, NavbarItem } from '~/components/Nav/Nav.styles'
 import Logo from '~/shared/components/Logo'
 import { Button } from '~/components/Button'
 import { REGULAR } from '~/shared/utils/styled'
-import {
-    useIsProjectDraftBusy,
-    useIsProjectDraftClean,
-    usePersistProjectCallback,
-    useProject,
-} from '~/stores/projectDraft'
+import { ProjectDraft, usePersistProjectCallback } from '~/stores/projectDraft'
 import routes from '~/routes'
 import { FloatingToolbar } from '~/components/FloatingToolbar'
 import { useInViewport } from '~/hooks/useInViewport'
@@ -39,11 +34,11 @@ const FlexNavbarItem = styled(NavbarItem)`
 `
 
 export default function EditorNav() {
-    const busy = useIsProjectDraftBusy()
+    const busy = ProjectDraft.useIsDraftBusy()
 
-    const clean = useIsProjectDraftClean()
+    const clean = ProjectDraft.useIsDraftClean()
 
-    const { id: projectId } = useProject() || {}
+    const { id: projectId } = ProjectDraft.useEntity() || {}
 
     const persist = usePersistProjectCallback()
 

--- a/src/pages/ProjectPage/EditorStreams.tsx
+++ b/src/pages/ProjectPage/EditorStreams.tsx
@@ -7,11 +7,7 @@ import {
 } from '~/services/streams'
 import SearchBar from '~/shared/components/SearchBar'
 import { StreamSelectTable } from '~/shared/components/StreamSelectTable'
-import {
-    useIsProjectDraftBusy,
-    useProject,
-    useUpdateProject,
-} from '~/stores/projectDraft'
+import { ProjectDraft } from '~/stores/projectDraft'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { ProjectType } from '~/shared/types'
 import { address0 } from '~/consts'
@@ -25,9 +21,9 @@ export default function EditorStreams() {
     const {
         type: projectType = ProjectType.OpenData,
         streams: projectStreams = EmptyStreams,
-    } = useProject({ hot: true }) || {}
+    } = ProjectDraft.useEntity({ hot: true }) || {}
 
-    const busy = useIsProjectDraftBusy()
+    const busy = ProjectDraft.useIsDraftBusy()
 
     const [searchValue, setSearchValue] = useState('')
 
@@ -45,7 +41,7 @@ export default function EditorStreams() {
 
     const abortControllerRef = useRef<AbortController>()
 
-    const update = useUpdateProject()
+    const update = ProjectDraft.useUpdateEntity()
 
     const chainId = useCurrentChainId()
 

--- a/src/pages/ProjectPage/ProjectEditorPage.tsx
+++ b/src/pages/ProjectPage/ProjectEditorPage.tsx
@@ -26,13 +26,7 @@ import useIsMounted from '~/shared/hooks/useIsMounted'
 import { useCurrentChainId } from '~/shared/stores/chain'
 import { ProjectType, SalePoint } from '~/shared/types'
 import { getConfigForChain, getConfigForChainByName } from '~/shared/web3/config'
-import {
-    useIsProjectDraftBusy,
-    useProject,
-    useProjectDraft,
-    useSetProjectDraftErrors,
-    useUpdateProject,
-} from '~/stores/projectDraft'
+import { ProjectDraft } from '~/stores/projectDraft'
 import { Chain } from '~/types'
 import { SalePointsPayload } from '~/types/projects'
 import { formatChainName } from '~/utils'
@@ -53,13 +47,13 @@ export default function ProjectEditorPage() {
         type = ProjectType.OpenData,
         creator = '',
         salePoints: existingSalePoints = EmptySalePoints,
-    } = useProject({ hot: true }) || {}
+    } = ProjectDraft.useEntity({ hot: true }) || {}
 
-    const busy = useIsProjectDraftBusy()
+    const busy = ProjectDraft.useIsDraftBusy()
 
-    const { fetching = false, errors = EmptyErrors } = useProjectDraft() || {}
+    const { fetching = false, errors = EmptyErrors } = ProjectDraft.useDraft() || {}
 
-    const update = useUpdateProject()
+    const update = ProjectDraft.useUpdateEntity()
 
     const chainId = useCurrentChainId()
 
@@ -114,7 +108,7 @@ export default function ProjectEditorPage() {
         })
     }
 
-    const setErrors = useSetProjectDraftErrors()
+    const setErrors = ProjectDraft.useSetDraftErrors()
 
     const isMounted = useIsMounted()
 

--- a/src/pages/ProjectPage/TermsOfUse.tsx
+++ b/src/pages/ProjectPage/TermsOfUse.tsx
@@ -6,18 +6,11 @@ import { Tick } from '~/shared/components/Checkbox'
 import Label from '~/shared/components/Ui/Label'
 import Input from '~/shared/components/Ui/Text/StyledInput'
 import { ProjectType } from '~/shared/types'
-import {
-    useIsProjectDraftBusy,
-    usePersistProjectCallback,
-    useProject,
-    useProjectDraft,
-    useSetProjectDraftErrors,
-    useUpdateProject,
-} from '~/stores/projectDraft'
+import { ProjectDraft, usePersistProjectCallback } from '~/stores/projectDraft'
 import { OpenDataPayload } from '~/types/projects'
 
 export default function TermsOfUse() {
-    const update = useUpdateProject()
+    const update = ProjectDraft.useUpdateEntity()
 
     const {
         termsOfUse: {
@@ -28,15 +21,17 @@ export default function TermsOfUse() {
             termsUrl,
             termsName,
         },
-    } = useProject({ hot: true }) || getEmptyParsedProject({ type: ProjectType.OpenData })
+    } =
+        ProjectDraft.useEntity({ hot: true }) ||
+        getEmptyParsedProject({ type: ProjectType.OpenData })
 
-    const { 'termsOfUse.termsUrl': termsUrlError } = useProjectDraft()?.errors || {}
+    const { 'termsOfUse.termsUrl': termsUrlError } = ProjectDraft.useDraft()?.errors || {}
 
-    const setErrors = useSetProjectDraftErrors()
+    const setErrors = ProjectDraft.useSetDraftErrors()
 
     const persist = usePersistProjectCallback()
 
-    const busy = useIsProjectDraftBusy()
+    const busy = ProjectDraft.useIsDraftBusy()
 
     return (
         <>

--- a/src/pages/ProjectPage/index.tsx
+++ b/src/pages/ProjectPage/index.tsx
@@ -25,12 +25,9 @@ import {
 } from '~/shared/stores/projectAbilities'
 import { ProjectType, SalePoint } from '~/shared/types'
 import {
-    ProjectDraftContext,
+    ProjectDraft,
     preselectSalePoint,
-    useInitProjectDraft,
     useIsAccessibleByCurrentWallet,
-    useIsProjectDraftBusy,
-    useProject,
 } from '~/stores/projectDraft'
 import { isProjectType } from '~/utils'
 import { useProjectByIdQuery } from '~/hooks/projects'
@@ -60,12 +57,12 @@ export function NewProjectPage() {
         return project
     }, [projectType])
 
-    const draftId = useInitProjectDraft(project)
+    const draftId = ProjectDraft.useInitDraft(project)
 
     return (
-        <ProjectDraftContext.Provider value={draftId}>
+        <ProjectDraft.DraftContext.Provider value={draftId}>
             <ProjectEditorPage />
-        </ProjectDraftContext.Provider>
+        </ProjectDraft.DraftContext.Provider>
     )
 }
 
@@ -85,7 +82,7 @@ export function ExistingProjectPageWrap() {
     const isFetching =
         projectQuery.isLoading || projectQuery.isFetching || !!behindBlockError
 
-    const draftId = useInitProjectDraft(isFetching ? undefined : project)
+    const draftId = ProjectDraft.useInitDraft(isFetching ? undefined : project)
 
     const placeholder = behindBlockError ? (
         <Layout>
@@ -105,14 +102,14 @@ export function ExistingProjectPageWrap() {
     )
 
     return (
-        <ProjectDraftContext.Provider value={draftId}>
+        <ProjectDraft.DraftContext.Provider value={draftId}>
             {project == null ? placeholder : <Outlet />}
-        </ProjectDraftContext.Provider>
+        </ProjectDraft.DraftContext.Provider>
     )
 }
 
 export function ProjectOverviewPage() {
-    const project = useProject()
+    const project = ProjectDraft.useEntity()
 
     if (!project) {
         return null
@@ -179,7 +176,7 @@ export function ProjectOverviewPage() {
 export function ProjectConnectPage() {
     const hasAccess = useIsAccessibleByCurrentWallet()
 
-    const project = useProject()
+    const project = ProjectDraft.useEntity()
 
     if (!project) {
         return null
@@ -222,7 +219,7 @@ export function ProjectConnectPage() {
 export function ProjectLiveDataPage() {
     const hasAccess = useIsAccessibleByCurrentWallet()
 
-    const project = useProject()
+    const project = ProjectDraft.useEntity()
 
     if (!project) {
         return null
@@ -257,9 +254,9 @@ export function ProjectLiveDataPage() {
 }
 
 export function ProjectTabbedPage() {
-    const { id = undefined, name = '', creator = '' } = useProject() || {}
+    const { id = undefined, name = '', creator = '' } = ProjectDraft.useEntity() || {}
 
-    const busy = useIsProjectDraftBusy()
+    const busy = ProjectDraft.useIsDraftBusy()
 
     const canEdit = useCurrentProjectAbility(ProjectPermission.Edit)
 

--- a/src/pages/SingleOperatorPage.tsx
+++ b/src/pages/SingleOperatorPage.tsx
@@ -875,7 +875,7 @@ const WarningCell = styled.div`
         height: 18px;
     }
 `
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const NoticeBar = styled.div`
     display: flex;
     align-items: center;
@@ -887,6 +887,7 @@ const NoticeBar = styled.div`
     padding: 8px 0;
 `
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const NoticeWrap = styled.div`
     display: grid;
     grid-template-columns: 18px 1fr;

--- a/src/shared/stores/projectAbilities.ts
+++ b/src/shared/stores/projectAbilities.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { produce } from 'immer'
 import { create } from 'zustand'
 import { getProjectPermissions } from '~/getters'
-import { useProject } from '~/stores/projectDraft'
+import { ProjectDraft } from '~/stores/projectDraft'
 import { address0 } from '~/consts'
 import { useWalletAccount } from './wallet'
 import { useCurrentChainId } from './chain'
@@ -146,5 +146,11 @@ function useProjectAbility(
 
 export function useCurrentProjectAbility(permission: ProjectPermission) {
     const chainId = useCurrentChainId()
-    return useProjectAbility(chainId, useProject()?.id, useWalletAccount(), permission)
+
+    return useProjectAbility(
+        chainId,
+        ProjectDraft.useEntity()?.id,
+        useWalletAccount(),
+        permission,
+    )
 }

--- a/src/stores/projectDraft.tsx
+++ b/src/stores/projectDraft.tsx
@@ -24,17 +24,7 @@ import networkPreflight from '~/utils/networkPreflight'
 import { validationErrorToast } from '~/utils/toast'
 import { toastedOperations } from '~/utils/toastedOperation'
 
-const {
-    DraftContext: ProjectDraftContext,
-    useDraft: useProjectDraft,
-    useEntity: useProject,
-    useInitDraft: useInitProjectDraft,
-    useIsDraftBusy: useIsProjectDraftBusy,
-    useIsDraftClean: useIsProjectDraftClean,
-    usePersistCallback,
-    useSetDraftErrors: useSetProjectDraftErrors,
-    useUpdateEntity: useUpdateProject,
-} = createDraftStore<ParsedProject>({
+export const ProjectDraft = createDraftStore<ParsedProject>({
     async persist({ entity }) {
         const operations: Operation[] = []
 
@@ -209,17 +199,6 @@ function eq(cold: ParsedProject, hot: ParsedProject) {
     return isEqual({ ...hot, adminFee: '' }, { ...cold, adminFee: '' })
 }
 
-export {
-    ProjectDraftContext,
-    useInitProjectDraft,
-    useIsProjectDraftBusy,
-    useIsProjectDraftClean,
-    useProject,
-    useProjectDraft,
-    useSetProjectDraftErrors,
-    useUpdateProject,
-}
-
 export function preselectSalePoint(project: ParsedProject) {
     if (project.type === ProjectType.OpenData) {
         return
@@ -268,7 +247,7 @@ function requiresAdminFeeUpdate(hot: ParsedProject, cold: ParsedProject) {
 export function useIsAccessibleByCurrentWallet() {
     const wallet = useWalletAccount()
 
-    const draft = useProjectDraft()
+    const draft = ProjectDraft.useDraft()
 
     const fetching = !!draft?.fetching
 
@@ -298,7 +277,7 @@ export function useIsAccessibleByCurrentWallet() {
 }
 
 export function usePersistProjectCallback() {
-    const persist = usePersistCallback()
+    const persist = ProjectDraft.usePersistCallback()
 
     const navigate = useNavigate()
 


### PR DESCRIPTION
In this PR I switch from re-exporting individual draft-related hooks (w/ custom names) to exporting \*just\* the `ProjectDraft` object. It's the same technique we've used on Streams (and `StreamDraft`). Example:
- `useProjectDraft` → `ProjectDraft.useDraft`,
- `useProject` → `ProjectDraft.useEntity`, etc.

The aim is to make things more readable and to know where things belong without digging too deeply.