### PR TITLE
FRONT-1765: Bring modals and toasts to front

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -114,12 +114,17 @@ const App = () => (
                 <Route path="*" element={<NotFoundPage />} />,
             </Route>
         </Routes>
-        <Container id={Layer.Modal} />
+        <ModalContainer id={Layer.Modal} />
         <ToastContainer id={Layer.Toast} />
     </Root>
 )
 
 export default App
+
+const ModalContainer = styled(Container)`
+    position: relative;
+    z-index: 11;
+`
 
 const ToastContainer = styled(Container)`
     bottom: 0;
@@ -128,7 +133,7 @@ const ToastContainer = styled(Container)`
     padding-bottom: 24px;
     padding-right: 24px;
     position: fixed;
-    z-index: 10;
+    z-index: 12;
 `
 
 function Root({ children }: { children: ReactNode }) {


### PR DESCRIPTION
I give modals and toasts layers 11 and 12 respectively. This makes them appear on top of anything else at all times.