### PR TITLE
FRONT-1839: Fix storage node state display

### DIFF
--- a/src/pages/AbstractStreamEditPage/HistorySection/StorageNodeList.tsx
+++ b/src/pages/AbstractStreamEditPage/HistorySection/StorageNodeList.tsx
@@ -23,7 +23,10 @@ function UnstyledStorageNodeList({ className, disabled = false }: Props) {
             <ul data-test-hook="Storage nodes">
                 {storageNodes.map(({ address, name }) => (
                     <li key={address}>
-                        <StorageNodeItem address={address} disabled={disabled}>
+                        <StorageNodeItem
+                            address={address.toLowerCase()}
+                            disabled={disabled}
+                        >
                             {name}
                         </StorageNodeItem>
                     </li>


### PR DESCRIPTION
In this PR I make sure we correctly display the fact that a stream comes with storage.