### PR TITLE
FRONT-1850: Fix stream creation flow

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,6 +16,7 @@ import {
     ExistingProjectPageWrap,
     NewProjectPage,
     ProjectConnectPage,
+    ProjectDraftPage,
     ProjectIndexRedirect,
     ProjectLiveDataPage,
     ProjectOverviewPage,
@@ -53,14 +54,22 @@ const App = () => (
             <Route errorElement={<GenericErrorPage />}>
                 <Route path="/hub/projects">
                     <Route index element={<ProjectListingPage />} />
-                    <Route path="new" element={<NewProjectPage />} />
-                    <Route path=":id" element={<ExistingProjectPageWrap />}>
-                        <Route index element={<ProjectIndexRedirect />} />
-                        <Route path="edit" element={<ProjectEditorPage />} />
-                        <Route element={<ProjectTabbedPage />}>
-                            <Route path="overview" element={<ProjectOverviewPage />} />
-                            <Route path="connect" element={<ProjectConnectPage />} />
-                            <Route path="live-data" element={<ProjectLiveDataPage />} />
+                    <Route element={<ProjectDraftPage />}>
+                        <Route path="new" element={<NewProjectPage />} />
+                        <Route path=":id" element={<ExistingProjectPageWrap />}>
+                            <Route index element={<ProjectIndexRedirect />} />
+                            <Route path="edit" element={<ProjectEditorPage />} />
+                            <Route element={<ProjectTabbedPage />}>
+                                <Route
+                                    path="overview"
+                                    element={<ProjectOverviewPage />}
+                                />
+                                <Route path="connect" element={<ProjectConnectPage />} />
+                                <Route
+                                    path="live-data"
+                                    element={<ProjectLiveDataPage />}
+                                />
+                            </Route>
                         </Route>
                     </Route>
                 </Route>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,8 +26,8 @@ import { SingleSponsorshipPage } from '~/pages/SingleSponsorshipPage'
 import { SponsorshipsPage } from '~/pages/SponsorshipsPage'
 import { StreamsPage } from '~/pages/StreamsPage'
 import {
-    NewStreamPage,
     StreamConnectPage,
+    StreamDraftPage,
     StreamEditPage,
     StreamIndexRedirect,
     StreamLiveDataPage,
@@ -66,11 +66,9 @@ const App = () => (
                 </Route>
                 <Route path="/hub/streams">
                     <Route index element={<StreamsPage />} />
-                    <Route path="new" element={<NewStreamPage />} />
-                    <Route path=":id">
-                        <Route index element={<StreamIndexRedirect />} />
+                    <Route element={<StreamDraftPage />}>
                         <Route
-                            path="overview"
+                            path="new"
                             element={
                                 <StreamTabbedPage stickySubmit>
                                     {(attach, ready) =>
@@ -81,9 +79,27 @@ const App = () => (
                                 </StreamTabbedPage>
                             }
                         />
-                        <Route element={<StreamTabbedPage />}>
-                            <Route path="connect" element={<StreamConnectPage />} />
-                            <Route path="live-data" element={<StreamLiveDataPage />} />
+                        <Route path=":id">
+                            <Route index element={<StreamIndexRedirect />} />
+                            <Route
+                                path="overview"
+                                element={
+                                    <StreamTabbedPage stickySubmit>
+                                        {(attach, ready) =>
+                                            ready ? (
+                                                <StreamEditPage saveButtonRef={attach} />
+                                            ) : null
+                                        }
+                                    </StreamTabbedPage>
+                                }
+                            />
+                            <Route element={<StreamTabbedPage />}>
+                                <Route path="connect" element={<StreamConnectPage />} />
+                                <Route
+                                    path="live-data"
+                                    element={<StreamLiveDataPage />}
+                                />
+                            </Route>
                         </Route>
                     </Route>
                 </Route>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -25,7 +25,6 @@ import {
 import { SingleOperatorPage } from '~/pages/SingleOperatorPage'
 import { SingleSponsorshipPage } from '~/pages/SingleSponsorshipPage'
 import { SponsorshipsPage } from '~/pages/SponsorshipsPage'
-import { StreamsPage } from '~/pages/StreamsPage'
 import {
     StreamConnectPage,
     StreamDraftPage,
@@ -34,6 +33,7 @@ import {
     StreamLiveDataPage,
     StreamTabbedPage,
 } from '~/pages/StreamPage'
+import { StreamsPage } from '~/pages/StreamsPage'
 import routes from '~/routes'
 import '~/shared/assets/stylesheets'
 import Globals from '~/shared/components/Globals'

--- a/src/pages/StreamPage/index.tsx
+++ b/src/pages/StreamPage/index.tsx
@@ -189,7 +189,7 @@ interface StreamTabbedPageProps {
 export function StreamDraftPage() {
     const { id: streamId } = useParams<{ id: string }>()
 
-    const draftId = StreamDraft.useInitDraft2(streamId)
+    const draftId = StreamDraft.useInitDraft(streamId)
 
     return (
         <StreamDraft.DraftContext.Provider value={draftId}>
@@ -211,11 +211,15 @@ export function StreamTabbedPage(props: StreamTabbedPageProps) {
 
     const draftId = StreamDraft.useDraftId()
 
+    const initialized = StreamDraft.useDraft()?.initialized || false
+
     useEffect(
         function assignEntity() {
-            assign(draftId, stream)
+            if (initialized) {
+                assign(draftId, stream)
+            }
         },
-        [assign, draftId, stream],
+        [assign, draftId, initialized, stream],
     )
 
     return (

--- a/src/pages/StreamPage/index.tsx
+++ b/src/pages/StreamPage/index.tsx
@@ -1,9 +1,10 @@
+import { StreamPermission } from '@streamr/sdk'
 import React, {
     MutableRefObject,
     ReactNode,
     RefCallback,
     useCallback,
-    useMemo,
+    useEffect,
 } from 'react'
 import {
     Link,
@@ -13,7 +14,6 @@ import {
     useNavigate,
     useParams,
 } from 'react-router-dom'
-import { StreamPermission } from '@streamr/sdk'
 import styled from 'styled-components'
 import { Button } from '~/components/Button'
 import ColoredBox from '~/components/ColoredBox'
@@ -42,7 +42,6 @@ import { DESKTOP, TABLET } from '~/shared/utils/styled'
 import { truncateStreamName } from '~/shared/utils/text'
 import {
     StreamDraft,
-    getEmptyStreamEntity,
     usePersistStreamDraft,
     useStreamEntityQuery,
 } from '~/stores/streamDraft'
@@ -182,25 +181,21 @@ export function StreamIndexRedirect() {
     return <Navigate to={routes.streams.overview({ id })} replace />
 }
 
-export function NewStreamPage() {
-    const stream = useMemo(() => getEmptyStreamEntity(), [])
-
-    const draftId = StreamDraft.useInitDraft(stream)
-
-    return (
-        <StreamDraft.DraftContext.Provider value={draftId}>
-            <StreamEntityForm stickySubmit>
-                {(attach, ready) =>
-                    ready ? <StreamEditPage saveButtonRef={attach} /> : null
-                }
-            </StreamEntityForm>
-        </StreamDraft.DraftContext.Provider>
-    )
-}
-
 interface StreamTabbedPageProps {
     children?: ReactNode | ((attach: RefCallback<Element>, ready: boolean) => ReactNode)
     stickySubmit?: boolean
+}
+
+export function StreamDraftPage() {
+    const { id: streamId } = useParams<{ id: string }>()
+
+    const draftId = StreamDraft.useInitDraft2(streamId)
+
+    return (
+        <StreamDraft.DraftContext.Provider value={draftId}>
+            <Outlet />
+        </StreamDraft.DraftContext.Provider>
+    )
 }
 
 export function StreamTabbedPage(props: StreamTabbedPageProps) {
@@ -212,28 +207,35 @@ export function StreamTabbedPage(props: StreamTabbedPageProps) {
 
     const isLoading = !stream && (query.isLoading || query.isFetching)
 
-    const draftId = StreamDraft.useInitDraft(isLoading ? undefined : stream)
+    const { assign } = StreamDraft.useDraftStore()
+
+    const draftId = StreamDraft.useDraftId()
+
+    useEffect(
+        function assignEntity() {
+            assign(draftId, stream)
+        },
+        [assign, draftId, stream],
+    )
 
     return (
-        <StreamDraft.DraftContext.Provider value={draftId}>
-            <StreamEntityForm stickySubmit={stickySubmit}>
-                {isLoading ? (
-                    <LoadingIndicator loading />
-                ) : query.error instanceof StreamNotFoundError ? (
-                    <>
-                        <LoadingIndicator />
-                        <NotFoundPageContent />
-                    </>
-                ) : query.error ? (
-                    <>
-                        <LoadingIndicator />
-                        <GenericErrorPageContent />
-                    </>
-                ) : (
-                    children
-                )}
-            </StreamEntityForm>
-        </StreamDraft.DraftContext.Provider>
+        <StreamEntityForm stickySubmit={stickySubmit}>
+            {isLoading ? (
+                <LoadingIndicator loading />
+            ) : query.error instanceof StreamNotFoundError ? (
+                <>
+                    <LoadingIndicator />
+                    <NotFoundPageContent />
+                </>
+            ) : query.error ? (
+                <>
+                    <LoadingIndicator />
+                    <GenericErrorPageContent />
+                </>
+            ) : (
+                children
+            )}
+        </StreamEntityForm>
     )
 }
 

--- a/src/stores/projectDraft.tsx
+++ b/src/stores/projectDraft.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { randomHex } from 'web3-utils'
 import { ValidationError } from '~/errors'
 import { getDataUnion } from '~/getters/du'
-import { ParsedProject, getEmptyParsedProject } from '~/parsers/ProjectParser'
+import { ParsedProject } from '~/parsers/ProjectParser'
 import routes from '~/routes'
 import {
     createProject,
@@ -179,11 +179,7 @@ export const ProjectDraft = createDraftStore<ParsedProject>({
     },
 
     getEmptyDraft() {
-        return getEmptyDraft(
-            getEmptyParsedProject({
-                type: ProjectType.OpenData,
-            }),
-        )
+        return getEmptyDraft<ParsedProject>(undefined)
     },
 
     isEqual: eq,

--- a/src/stores/streamDraft.tsx
+++ b/src/stores/streamDraft.tsx
@@ -1,13 +1,13 @@
-import { useQuery } from '@tanstack/react-query'
-import isEqual from 'lodash/isEqual'
-import uniqueId from 'lodash/uniqueId'
-import React, { useCallback } from 'react'
-import { Link, useMatch, useParams } from 'react-router-dom'
 import StreamrClient, {
     PermissionAssignment,
     Stream,
     StreamPermission,
 } from '@streamr/sdk'
+import { useQuery } from '@tanstack/react-query'
+import isEqual from 'lodash/isEqual'
+import uniqueId from 'lodash/uniqueId'
+import React, { useCallback } from 'react'
+import { Link, useMatch, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { toaster } from 'toasterhea'
 import { z } from 'zod'
@@ -36,7 +36,7 @@ import { toastedOperations } from '~/utils/toastedOperation'
 import getChainId from '~/utils/web3/getChainId'
 
 export const StreamDraft = createDraftStore<ParsedStream>({
-    getEmptyDraft: () => getEmptyDraft(getEmptyStreamEntity()),
+    getEmptyDraft: () => getEmptyDraft<ParsedStream>(undefined),
 
     prefix: 'StreamDraft-',
 })
@@ -71,11 +71,17 @@ export function useStreamEntityQuery() {
 
     const chainId = useCurrentChainId()
 
+    const draft = StreamDraft.useBoundDraft(streamId)
+
     return useQuery({
         queryKey: ['useStreamEntityQuery', chainId, streamId],
         queryFn: async () => {
+            if (draft?.entity) {
+                return draft.entity.cold
+            }
+
             if (!streamId) {
-                return null
+                return getEmptyStreamEntity()
             }
 
             try {


### PR DESCRIPTION
This PR addresses an issue where during a multi-step stream creation (metadata + permisisons and/or storage) the changes done to permissions or storage (anything beyond metadata info) would \*seem\* lost after relocating from `/streams/new` to `/streams/:id`.

Additionally I eliminate the need to re-fetch newly created streams (and the weird blank page loading screen that accompanies the fetching). Better UX!

---

- [x] Fix tests.
- [x] Since projects use `draft` utility as well (which got modded in this PR) ensure project flows are intact.