### PR TITLE
Network subgraph URL tweaks (and SDK update → v5.3.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@sambego/storybook-styles": "^1.0.0",
                 "@sentry/browser": "^7.51.2",
                 "@sentry/integrations": "^7.51.2",
-                "@streamr/config": "^5.3.5",
+                "@streamr/config": "^5.3.6",
                 "@streamr/hub-contracts": "^1.0.2",
                 "@streamr/network-contracts": "^7.1.1",
                 "@streamr/sdk": "^100.2.3",
@@ -15731,9 +15731,9 @@
             "integrity": "sha512-rv9+XE9s6/S+QFH/TThiMYDGD2ozLw02RsOBKLGrbZQQCGhEbSCMg+Exjd2UHbsCE5uZDmy5vLzmJzFkGVPPmA=="
         },
         "node_modules/@streamr/config": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.3.5.tgz",
-            "integrity": "sha512-cP1/0Y5R9A3D2ua9iuliEzC9RWyrmuQROuym/jWggDd1H7vtQS5AB9AkgAq64eKmx1IoBHn7rfqYxBNdxjWs5g=="
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.3.6.tgz",
+            "integrity": "sha512-ZVYdA5s5aLVIeVbYajQzW6y9bi81VCJEY55k9Bh7atVDoO3qw/VZhmq9JcgXSqDfnzWoJ0lIh1swFwN9eKIfdA=="
         },
         "node_modules/@streamr/dht": {
             "version": "100.2.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@sambego/storybook-styles": "^1.0.0",
         "@sentry/browser": "^7.51.2",
         "@sentry/integrations": "^7.51.2",
-        "@streamr/config": "^5.3.5",
+        "@streamr/config": "^5.3.6",
         "@streamr/hub-contracts": "^1.0.2",
         "@streamr/network-contracts": "^7.1.1",
         "@streamr/sdk": "^100.2.3",

--- a/src/config/chains.toml
+++ b/src/config/chains.toml
@@ -1,12 +1,9 @@
 [dev2]
+dataUnionJoinServerUrl = ":5555"
 dockerHost = "localhost"
 marketplaceChains = ['dev2']
 networkSubgraphUrl = ":8800/subgraphs/name/streamr-dev/network-subgraphs"
 streamIndexerUrl = ":4001/api"
-
-[dev2.client]
-dataUnionJoinServerUrl = ":5555"
-networkSubgraphUrl = ":8800/subgraphs/name/streamr-dev/network-subgraphs"
 
 [[dev2.storageNodes]]
 name = "Local (broker-node-storage-1)"
@@ -17,12 +14,8 @@ chainId = 31337
 name = "streamr-dev/dataunion"
 
 [polygonAmoy]
-marketplaceChains = ['polygonAmoy']
-networkSubgraphUrl = "https://api.thegraph.com/subgraphs/name/samt1803/network-subgraphs"
-
-[polygonAmoy.client]
 dataUnionJoinServerUrl = "https://join.dataunions.org/"
-networkSubgraphUrl = "https://api.thegraph.com/subgraphs/name/samt1803/network-subgraphs"
+marketplaceChains = ['polygonAmoy']
 
 [[polygonAmoy.storageNodes]]
 name = "Streamr Germany"
@@ -33,7 +26,6 @@ chainId = 80002
 name = "samt1803/dataunion-subgraphs"
 
 [polygon]
-enforceLocalNetworkSubgraphUrl = true
 marketplaceChains = ['gnosis', 'polygon']
 networkSubgraphUrl = "https://gateway-arbitrum.network.thegraph.com/api/8bcbd55cdd1369cadb0bb813d9817776/subgraphs/id/EGWFdhhiWypDuz22Uy7b3F69E9MEkyfU9iAQMttkH5Rj"
 streamIndexerUrl = "https://stream-metrics.streamr.network/api"

--- a/src/config/chains.toml
+++ b/src/config/chains.toml
@@ -16,6 +16,7 @@ name = "streamr-dev/dataunion"
 [polygonAmoy]
 dataUnionJoinServerUrl = "https://join.dataunions.org/"
 marketplaceChains = ['polygonAmoy']
+networkSubgraphUrl = "https://api.studio.thegraph.com/query/58729/streamr-amoy-testnet/version/latest"
 
 [[polygonAmoy.storageNodes]]
 name = "Streamr Germany"

--- a/src/getters/getChainConfigExtension.ts
+++ b/src/getters/getChainConfigExtension.ts
@@ -6,11 +6,7 @@ import { getSymbolicChainName } from '~/shared/web3/config'
 import formatConfigUrl from '~/utils/formatConfigUrl'
 
 const ChainConfigExtension = z.object({
-    client: z
-        .object({
-            networkSubgraphUrl: z.string().optional(),
-        })
-        .optional(),
+    dataUnionJoinServerUrl: z.string().optional(),
     dataunionGraphNames: z
         .array(
             z.object({
@@ -20,7 +16,6 @@ const ChainConfigExtension = z.object({
         )
         .optional()
         .default([]),
-    dataUnionJoinServerUrl: z.string().optional(),
     dockerHost: z.string().optional(),
     ipfs: z
         .object({
@@ -37,11 +32,7 @@ const ChainConfigExtension = z.object({
             projectId: '2KjYUpR265h6R5M5njkSue5RGm7',
         }),
     marketplaceChains: z.array(z.string()).optional().default([]),
-    networkSubgraphUrl: z
-        .string()
-        .optional()
-        .default('https://api.thegraph.com/subgraphs/name/streamr-dev/network'),
-    enforceLocalNetworkSubgraphUrl: z.boolean().optional().default(false),
+    networkSubgraphUrl: z.string().optional(),
     sponsorshipPaymentToken: z.string().optional().default('DATA'),
     storageNodes: z
         .array(
@@ -69,25 +60,17 @@ const parsedConfig = z
                 }
 
                 const {
-                    client,
                     dataUnionJoinServerUrl,
                     dockerHost,
                     networkSubgraphUrl,
                     streamIndexerUrl,
                 } = extension
 
-                if (typeof client?.networkSubgraphUrl === 'string') {
-                    client.networkSubgraphUrl = formatConfigUrl(
-                        client.networkSubgraphUrl,
-                        {
-                            dockerHost,
-                        },
-                    )
+                if (networkSubgraphUrl) {
+                    extension.networkSubgraphUrl = formatConfigUrl(networkSubgraphUrl, {
+                        dockerHost,
+                    })
                 }
-
-                extension.networkSubgraphUrl = formatConfigUrl(networkSubgraphUrl, {
-                    dockerHost,
-                })
 
                 if (typeof dataUnionJoinServerUrl === 'string') {
                     extension.dataUnionJoinServerUrl = formatConfigUrl(

--- a/src/getters/getClientConfig.ts
+++ b/src/getters/getClientConfig.ts
@@ -2,6 +2,7 @@ import { ChainConnectionInfo, StreamrClientConfig } from '@streamr/sdk'
 import formatConfigUrl from '~/utils/formatConfigUrl'
 import { getConfigForChain } from '~/shared/web3/config'
 import { getChainConfigExtension } from './getChainConfigExtension'
+import { getGraphUrl } from './getGraphClient'
 
 export default function getClientConfig(
     chainId: number,
@@ -11,8 +12,6 @@ export default function getClientConfig(
     const config: StreamrClientConfig = {
         metrics: false,
     }
-
-    const { client } = getChainConfigExtension(chainId)
 
     // Set network entrypoints if provided
     if (chainConfig.entryPoints && chainConfig.entryPoints.length > 0) {
@@ -64,13 +63,9 @@ export default function getClientConfig(
         }
     })
 
-    if (client?.networkSubgraphUrl) {
-        contracts.theGraphUrl = client.networkSubgraphUrl
-    }
+    contracts.theGraphUrl = getGraphUrl(chainId)
 
-    if (Object.keys(contracts).length > 0) {
-        config.contracts = contracts
-    }
+    config.contracts = contracts
 
     return {
         ...config,

--- a/src/getters/getGraphClient.ts
+++ b/src/getters/getGraphClient.ts
@@ -19,17 +19,18 @@ export function getGraphClient(chainId: number) {
     return graphClient
 }
 
-function getGraphUrl(chainId: number): string {
-    const { theGraphUrl: url } = getConfigForChain(chainId)
+export function getGraphUrl(chainId: number): string {
+    const { theGraphUrl: defaultUrl } = getConfigForChain(chainId)
 
-    const { networkSubgraphUrl: fallbackUrl, enforceLocalNetworkSubgraphUrl } =
-        getChainConfigExtension(chainId)
+    const { networkSubgraphUrl: customUrl } = getChainConfigExtension(chainId)
 
-    if (enforceLocalNetworkSubgraphUrl) {
-        return fallbackUrl
+    const url = customUrl || defaultUrl
+
+    if (!url) {
+        throw new Error(`Missing network subgraph url for chain ${chainId}`)
     }
 
-    return url || fallbackUrl
+    return url
 }
 
 const dataUnionGraphClients: Partial<
@@ -45,7 +46,7 @@ export function getDataUnionGraphClient(chainId: number) {
         throw new Error(`No dataunionGraphNames defined in config for chain ${chainId}!`)
     }
 
-    const { networkSubgraphUrl } = getChainConfigExtension(chainId)
+    const networkSubgraphUrl = getGraphUrl(chainId)
 
     const { origin } = new URL(networkSubgraphUrl)
 


### PR DESCRIPTION
In this PR I eliminate confusion on the graph URL piece (we call it `networkSubgraphUrl`).

We used to have a "fallback" URL within Hub. Now it's the custom, and if it's defined that's what we use. And we use the one coming from the config package (called `theGraphUrl`) otherwise.

If none is specified I make the code explode. Using some default endpoint does not help!