### PR TITLE
FRONT-1818: Fix "Your streams" list

### DIFF
--- a/src/hooks/streams.tsx
+++ b/src/hooks/streams.tsx
@@ -90,7 +90,7 @@ async function getStreamsFromIndexer(
         pageParam: cursor,
         pageSize,
         search,
-        streamIds,
+        streamIds: streamIdsOption,
     } = options
 
     const client = getIndexerClient(chainId)
@@ -102,6 +102,21 @@ async function getStreamsFromIndexer(
             streams: [],
         }
     }
+
+    const streamIds =
+        !owner || owner === address0
+            ? streamIdsOption
+            : await (async () => {
+                  try {
+                      return (
+                          await getStreamsFromGraph(chainId, {
+                              owner,
+                          })
+                      ).streams.map(({ id }) => id)
+                  } catch (e) {
+                      return []
+                  }
+              })()
 
     const {
         data: { streams: result },
@@ -124,7 +139,7 @@ async function getStreamsFromIndexer(
                     ? IndexerOrderDirection.Desc
                     : undefined,
             search,
-            owner,
+            owner: undefined,
             cursor,
         },
     })

--- a/src/hooks/streams.tsx
+++ b/src/hooks/streams.tsx
@@ -111,6 +111,8 @@ async function getStreamsFromIndexer(
                       return (
                           await getStreamsFromGraph(chainId, {
                               owner,
+                              pageSize: 1000,
+                              search,
                           })
                       ).streams.map(({ id }) => id)
                   } catch (e) {


### PR DESCRIPTION
The indexer doesn't allow us to list streams by permissions. Instead I use stream ids from the graph (which does) to accurately ask the indexer for "my" collection of streams.

Hacky.