### PR TITLE
Optimize stream list queries

### DIFF
--- a/src/components/QueriedStreamsTable.tsx
+++ b/src/components/QueriedStreamsTable.tsx
@@ -1,5 +1,7 @@
-import { UseInfiniteQueryResult, useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { UseInfiniteQueryResult, useQuery } from '@tanstack/react-query'
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
+import { LoadMoreButton } from '~/components/LoadMore'
+import { StreamIdCell } from '~/components/Table'
 import {
     GetStreamsResult,
     StreamStats,
@@ -9,10 +11,8 @@ import {
 } from '~/hooks/streams'
 import routes from '~/routes'
 import { ScrollTableCore } from '~/shared/components/ScrollTable/ScrollTable'
-import { OrderDirection } from '~/types'
-import { LoadMoreButton } from '~/components/LoadMore'
-import { StreamIdCell } from '~/components/Table'
 import { useCurrentChainId } from '~/shared/stores/chain'
+import { OrderDirection } from '~/types'
 
 interface Props {
     noDataFirstLine?: ReactNode

--- a/src/components/QueriedStreamsTable.tsx
+++ b/src/components/QueriedStreamsTable.tsx
@@ -1,6 +1,12 @@
-import { UseInfiniteQueryResult } from '@tanstack/react-query'
-import React, { ReactNode, useEffect, useRef } from 'react'
-import { GetStreamsResult, StreamsOrderBy, isIndexerColumn } from '~/hooks/streams'
+import { UseInfiniteQueryResult, useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import React, { ReactNode, useEffect, useRef, useState } from 'react'
+import {
+    GetStreamsResult,
+    StreamStats,
+    StreamsOrderBy,
+    getStreamsFromIndexer,
+    isIndexerColumn,
+} from '~/hooks/streams'
 import routes from '~/routes'
 import { ScrollTableCore } from '~/shared/components/ScrollTable/ScrollTable'
 import { OrderDirection } from '~/types'
@@ -15,7 +21,6 @@ interface Props {
     orderBy?: StreamsOrderBy
     orderDirection?: OrderDirection
     query: UseInfiniteQueryResult<GetStreamsResult, unknown>
-    statsQuery: UseInfiniteQueryResult<GetStreamsResult | undefined, unknown>
 }
 
 export function QueriedStreamsTable({
@@ -25,16 +30,14 @@ export function QueriedStreamsTable({
     orderBy = 'mps',
     orderDirection,
     query,
-    statsQuery,
 }: Props) {
-    const streams = query.data?.pages.flatMap((d) => d.streams) || []
+    const pages = query.data?.pages || []
 
-    const streamStats = Object.fromEntries(
-        (statsQuery.data?.pages || [])
-            .filter((p) => p)
-            .flatMap((p) => p!.streams)
-            .map((s) => [s!.id, s]),
-    )
+    const streams = pages.flatMap((d) => d.streams) || []
+
+    const [streamStats, setStreamStats] = useState<
+        Record<string, StreamStats | undefined>
+    >({})
 
     const chainId = useCurrentChainId()
 
@@ -59,6 +62,18 @@ export function QueriedStreamsTable({
 
     return (
         <>
+            {pages.map((page) => (
+                <StreamStatsLoader
+                    key={page.pageId}
+                    page={page}
+                    onStats={(stats) => {
+                        setStreamStats((current) => ({
+                            ...current,
+                            ...stats,
+                        }))
+                    }}
+                />
+            ))}
             <ScrollTableCore
                 noDataFirstLine={noDataFirstLine}
                 noDataSecondLine={noDataSecondLine}
@@ -129,4 +144,60 @@ export function QueriedStreamsTable({
             )}
         </>
     )
+}
+
+interface StreamStatsLoaderProps {
+    page: GetStreamsResult
+    onStats?(stats: Partial<Record<string, StreamStats>>): void
+}
+
+function StreamStatsLoader({ onStats, page }: StreamStatsLoaderProps) {
+    const chainId = useCurrentChainId()
+
+    const streamIdsRef = useRef(page.streams.map(({ id }) => id))
+
+    const { data: result } = useQuery({
+        queryKey: ['StreamStatsLoader.statsQuery', chainId, page.pageId, page.source],
+        queryFn: async (): Promise<Partial<Record<string, StreamStats>>> => {
+            if (page.source === 'indexer') {
+                return {}
+            }
+
+            try {
+                const { streams } = await getStreamsFromIndexer(chainId, {
+                    force: true,
+                    pageSize: Math.min(1000, streamIdsRef.current.length),
+                    streamIds: streamIdsRef.current,
+                })
+
+                const stats: Partial<Record<string, StreamStats>> = {}
+
+                for (const { id, messagesPerSecond, peerCount } of streams) {
+                    stats[id] = {
+                        messagesPerSecond,
+                        peerCount,
+                    }
+                }
+
+                return stats
+            } catch (_) {
+                // ¯\_(ツ)_/¯
+            }
+
+            return {}
+        },
+        staleTime: 5 * 60000,
+    })
+
+    const resultRef = useRef(result)
+
+    if (resultRef.current !== result) {
+        resultRef.current = result
+
+        if (result) {
+            onStats?.(result)
+        }
+    }
+
+    return <></>
 }

--- a/src/hooks/streams.tsx
+++ b/src/hooks/streams.tsx
@@ -361,7 +361,7 @@ export function useStreamsStatsQuery() {
 
             return await getter(chainId, {
                 force: true,
-                pageSize: streamIds.length,
+                pageSize: Math.min(1000, streamIds.length),
                 streamIds,
             })
         },

--- a/src/hooks/streams.tsx
+++ b/src/hooks/streams.tsx
@@ -1,30 +1,31 @@
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import uniqueId from 'lodash/uniqueId'
 import { address0 } from '~/consts'
 import {
-    Stream_Filter,
-    Stream_OrderBy,
-    OrderDirection as GraphOrderDirection,
-    GetPagedStreamsQuery,
-    GetPagedStreamsQueryVariables,
-    GetPagedStreamsDocument,
-    StreamPermission,
-} from '~/generated/gql/network'
-import { getGraphClient, getIndexerClient } from '~/getters/getGraphClient'
-import { useWalletAccount } from '~/shared/stores/wallet'
-import { OrderDirection } from '~/types'
-import {
+    GetGlobalStreamsStatsDocument,
+    GetGlobalStreamsStatsQuery,
+    GetGlobalStreamsStatsQueryVariables,
     GetStreamsDocument as GetIndexerStreamsDocument,
     GetStreamsQuery as GetIndexerStreamsQuery,
     GetStreamsQueryVariables as GetIndexerStreamsQueryVariables,
-    OrderDirection as IndexerOrderDirection,
     StreamOrderBy as IndexerOrderBy,
-    GetGlobalStreamsStatsQuery,
-    GetGlobalStreamsStatsQueryVariables,
-    GetGlobalStreamsStatsDocument,
+    OrderDirection as IndexerOrderDirection,
 } from '~/generated/gql/indexer'
+import {
+    GetPagedStreamsDocument,
+    GetPagedStreamsQuery,
+    GetPagedStreamsQueryVariables,
+    OrderDirection as GraphOrderDirection,
+    StreamPermission,
+    Stream_Filter,
+    Stream_OrderBy,
+} from '~/generated/gql/network'
 import { getDescription } from '~/getters'
-import { useCurrentChainId } from '~/shared/stores/chain'
 import { getChainConfigExtension } from '~/getters/getChainConfigExtension'
+import { getGraphClient, getIndexerClient } from '~/getters/getGraphClient'
+import { useCurrentChainId } from '~/shared/stores/chain'
+import { useWalletAccount } from '~/shared/stores/wallet'
+import { OrderDirection } from '~/types'
 
 export enum StreamsTabOption {
     All = 'all',
@@ -38,13 +39,6 @@ export function isStreamsTabOption(value: unknown): value is StreamsTabOption {
 export type StreamsOrderBy = 'id' | 'mps' | 'peerCount'
 
 export interface UseStreamsQueryOptions {
-    onBatch?: ({
-        streamIds,
-        source,
-    }: {
-        streamIds: string[]
-        source: 'graph' | 'indexer'
-    }) => void
     orderBy: StreamsOrderBy
     orderDirection: OrderDirection
     pageSize?: number
@@ -64,18 +58,22 @@ interface GetStreamsOptions {
     streamIds?: string[]
 }
 
+export interface StreamStats {
+    messagesPerSecond: number | undefined
+    peerCount: number | undefined
+}
+
 export interface GetStreamsResult {
     hasNextPage: boolean
     nextPageParam: string | null
-    streams: {
+    streams: (StreamStats & {
         description: string
         id: string
-        messagesPerSecond: number | undefined
-        peerCount: number | undefined
         publisherCount: number | undefined
-        source: 'indexer' | 'graph'
         subscriberCount: number | undefined
-    }[]
+    })[]
+    pageId: string
+    source: 'indexer' | 'graph'
 }
 
 export async function getStreamsFromIndexer(
@@ -99,6 +97,8 @@ export async function getStreamsFromIndexer(
         return {
             hasNextPage: false,
             nextPageParam: null,
+            pageId: uniqueId('StreamsPage-'),
+            source: 'indexer',
             streams: [],
         }
     }
@@ -107,6 +107,12 @@ export async function getStreamsFromIndexer(
         !owner || owner === address0
             ? streamIdsOption
             : await (async () => {
+                  /**
+                   * Indexer keeps track of stream owners but have no information on secondary
+                   * permissions. Here we ask the regular graph for stream ids for the current
+                   * address and use them to query the indexer. Hacky.
+                   */
+
                   try {
                       const where: Stream_Filter = {
                           permissions_: {
@@ -171,13 +177,14 @@ export async function getStreamsFromIndexer(
         messagesPerSecond,
         peerCount,
         publisherCount: s.publisherCount || undefined,
-        source: 'graph' as const,
         subscriberCount: s.subscriberCount || undefined,
     }))
 
     return {
         hasNextPage: result.cursor != null,
         nextPageParam: result.cursor || null,
+        pageId: uniqueId('StreamsPage-'),
+        source: 'indexer',
         streams,
     }
 }
@@ -262,28 +269,21 @@ async function getStreamsFromGraph(
             messagesPerSecond: undefined,
             peerCount: undefined,
             publisherCount,
-            source: 'indexer' as const,
             subscriberCount,
         }
     })
 
     return {
-        streams,
         hasNextPage: streams.length > pageSize,
         nextPageParam: streams[streams.length - 1].id,
+        pageId: uniqueId('StreamsPage-'),
+        source: 'graph',
+        streams,
     }
 }
 
 export function useStreamsQuery(options: UseStreamsQueryOptions) {
-    const {
-        onBatch,
-        orderBy,
-        orderDirection,
-        pageSize = 10,
-        search,
-        tab,
-        streamIds,
-    } = options
+    const { orderBy, orderDirection, pageSize = 10, search, tab, streamIds } = options
 
     const account = useWalletAccount()
 
@@ -308,25 +308,25 @@ export function useStreamsQuery(options: UseStreamsQueryOptions) {
                 ? getStreamsFromIndexer
                 : getStreamsFromGraph
 
-            const { streams, nextPageParam, hasNextPage } = await getter(chainId, {
-                force: true,
-                orderBy,
-                orderDirection,
-                owner: owner?.toLowerCase(),
-                pageParam,
-                pageSize,
-                search: search?.toLowerCase() || undefined,
-                streamIds,
-            })
-
-            onBatch?.({
-                streamIds: streams.map((s) => s.id),
-                source: isIndexerColumn(chainId, orderBy) ? 'indexer' : 'graph',
-            })
+            const { streams, nextPageParam, hasNextPage, source, pageId } = await getter(
+                chainId,
+                {
+                    force: true,
+                    orderBy,
+                    orderDirection,
+                    owner: owner?.toLowerCase(),
+                    pageParam,
+                    pageSize,
+                    search: search?.toLowerCase() || undefined,
+                    streamIds,
+                },
+            )
 
             return {
                 hasNextPage,
                 nextPageParam,
+                pageId,
+                source,
                 streams,
             }
         },
@@ -343,31 +343,6 @@ export function isIndexerColumn(chainId: number, orderBy: StreamsOrderBy) {
     }
 
     return orderBy === 'mps' || orderBy === 'peerCount'
-}
-
-export function useStreamsStatsQuery() {
-    const chainId = useCurrentChainId()
-
-    return useInfiniteQuery({
-        queryKey: ['useStreamsStatsQuery', chainId],
-        queryFn: async ({ pageParam }) => {
-            if (pageParam == null) {
-                return
-            }
-
-            const { useIndexer, streamIds } = pageParam
-
-            const getter = useIndexer ? getStreamsFromIndexer : getStreamsFromGraph
-
-            return await getter(chainId, {
-                force: true,
-                pageSize: Math.min(1000, streamIds.length),
-                streamIds,
-            })
-        },
-        staleTime: 60 * 1000, // 1 minute
-        keepPreviousData: true,
-    })
 }
 
 interface GetStatsFromPermissionsResult {

--- a/src/hooks/streams.tsx
+++ b/src/hooks/streams.tsx
@@ -78,7 +78,7 @@ export interface GetStreamsResult {
     }[]
 }
 
-async function getStreamsFromIndexer(
+export async function getStreamsFromIndexer(
     chainId: number,
     options: GetStreamsOptions = {},
 ): Promise<GetStreamsResult> {

--- a/src/pages/ProjectPage/EditorStreams.tsx
+++ b/src/pages/ProjectPage/EditorStreams.tsx
@@ -1,17 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import {
-    IndexerStream,
-    TheGraphStream,
-    getStreamsFromIndexer,
-    getStreamsOwnedBy,
-} from '~/services/streams'
+import { address0 } from '~/consts'
+import { getStreamsFromIndexer } from '~/hooks/streams'
+import { IndexerStream, TheGraphStream, getStreamsOwnedBy } from '~/services/streams'
 import SearchBar from '~/shared/components/SearchBar'
 import { StreamSelectTable } from '~/shared/components/StreamSelectTable'
-import { ProjectDraft } from '~/stores/projectDraft'
+import { useCurrentChainId } from '~/shared/stores/chain'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { ProjectType } from '~/shared/types'
-import { address0 } from '~/consts'
-import { useCurrentChainId } from '~/shared/stores/chain'
+import { ProjectDraft } from '~/stores/projectDraft'
 
 const PageSize = 10
 
@@ -129,7 +125,10 @@ export default function EditorStreams() {
 
         setTimeout(async () => {
             try {
-                const stats = await getStreamsFromIndexer(chainId, streamIds)
+                const { streams: stats } = await getStreamsFromIndexer(chainId, {
+                    pageSize: Math.min(1000, streamIds.length),
+                    streamIds,
+                })
 
                 if (!mounted || !stats.length) {
                     return

--- a/src/pages/ProjectPage/index.tsx
+++ b/src/pages/ProjectPage/index.tsx
@@ -1,13 +1,20 @@
 import React, { useEffect, useMemo } from 'react'
 import { Link, Navigate, Outlet, useParams, useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
+import { BehindBlockErrorDisplay } from '~/components/BehindBlockErrorDisplay'
 import { Button } from '~/components/Button'
 import ColoredBox from '~/components/ColoredBox'
 import Layout, { LayoutColumn } from '~/components/Layout'
 import NetworkPageSegment, { Pad, SegmentGrid } from '~/components/NetworkPageSegment'
 import { QueriedStreamsTable } from '~/components/QueriedStreamsTable'
 import { TermsOfUse } from '~/components/TermsOfUse'
-import { StreamsOrderBy, useStreamsQuery, useStreamsStatsQuery } from '~/hooks/streams'
+import {
+    useInitialBehindIndexError,
+    useLatestBehindBlockError,
+    useRefetchQueryBehindIndexEffect,
+} from '~/hooks'
+import { useProjectByIdQuery } from '~/hooks/projects'
+import { StreamsOrderBy, useStreamsQuery } from '~/hooks/streams'
 import { useTableOrder } from '~/hooks/useTableOrder'
 import ProjectHero from '~/marketplace/containers/ProjectPage/Hero/ProjectHero2'
 import NotFoundPage from '~/pages/NotFoundPage'
@@ -30,13 +37,6 @@ import {
     useIsAccessibleByCurrentWallet,
 } from '~/stores/projectDraft'
 import { isProjectType } from '~/utils'
-import { useProjectByIdQuery } from '~/hooks/projects'
-import {
-    useInitialBehindIndexError,
-    useLatestBehindBlockError,
-    useRefetchQueryBehindIndexEffect,
-} from '~/hooks'
-import { BehindBlockErrorDisplay } from '~/components/BehindBlockErrorDisplay'
 import { AccessManifest } from './AccessManifest'
 import GetAccess from './GetAccess'
 import ProjectEditorPage from './ProjectEditorPage'
@@ -349,17 +349,7 @@ function StreamTable({ streamIds }: { streamIds: string[] }) {
         setOrder,
     } = useTableOrder<StreamsOrderBy>()
 
-    const streamsStatsQuery = useStreamsStatsQuery()
-
     const streamsQuery = useStreamsQuery({
-        onBatch({ streamIds, source }) {
-            streamsStatsQuery.fetchNextPage({
-                pageParam: {
-                    streamIds,
-                    useIndexer: source !== 'indexer',
-                },
-            })
-        },
         orderBy,
         orderDirection,
         streamIds,
@@ -371,7 +361,6 @@ function StreamTable({ streamIds }: { streamIds: string[] }) {
             orderBy={orderBy}
             orderDirection={orderDirection}
             query={streamsQuery}
-            statsQuery={streamsStatsQuery}
         />
     )
 }

--- a/src/pages/StreamsPage.tsx
+++ b/src/pages/StreamsPage.tsx
@@ -19,7 +19,6 @@ import {
     isStreamsTabOption,
     useGlobalStreamStatsQuery,
     useStreamsQuery,
-    useStreamsStatsQuery,
 } from '~/hooks/streams'
 import { useTableOrder } from '~/hooks/useTableOrder'
 import routes from '~/routes'
@@ -58,17 +57,7 @@ export function StreamsPage() {
         setOrder,
     } = useTableOrder<StreamsOrderBy>()
 
-    const streamsStatsQuery = useStreamsStatsQuery()
-
     const streamsQuery = useStreamsQuery({
-        onBatch({ streamIds, source }) {
-            streamsStatsQuery.fetchNextPage({
-                pageParam: {
-                    streamIds,
-                    useIndexer: source !== 'indexer',
-                },
-            })
-        },
         orderBy,
         orderDirection,
         search,
@@ -151,7 +140,6 @@ export function StreamsPage() {
                             orderBy={orderBy}
                             orderDirection={orderDirection}
                             query={streamsQuery}
-                            statsQuery={streamsStatsQuery}
                         />
                     </NetworkPageSegment>
                 </SegmentGrid>

--- a/src/services/streams.ts
+++ b/src/services/streams.ts
@@ -1,8 +1,6 @@
-import omitBy from 'lodash/omitBy'
 import isEmpty from 'lodash/isEmpty'
+import omitBy from 'lodash/omitBy'
 import { address0 } from '~/consts'
-import { post } from '~/shared/utils/api'
-import { getGraphClient } from '~/getters/getGraphClient'
 import {
     GetPagedStreamsDocument,
     GetPagedStreamsQuery,
@@ -16,7 +14,7 @@ import {
     Stream_OrderBy,
     StreamPermission,
 } from '~/generated/gql/network'
-import { getChainConfigExtension } from '~/getters/getChainConfigExtension'
+import { getGraphClient } from '~/getters/getGraphClient'
 import { OrderDirection } from '~/types'
 
 export type TheGraphStreamPermission = {
@@ -195,42 +193,6 @@ export type IndexerResult = {
     streams: Array<IndexerStream>
     cursor: string | null | undefined
     hasNextPage: boolean
-}
-
-/**
- * @deprecated
- */
-export const getStreamsFromIndexer = async (
-    chainId: number,
-    streamIds: Array<string>,
-): Promise<Array<IndexerStream>> => {
-    const { streamIndexerUrl } = getChainConfigExtension(chainId)
-
-    if (!streamIndexerUrl || streamIds == null || streamIds.length === 0) {
-        return []
-    }
-
-    const result = await post({
-        url: streamIndexerUrl,
-        data: {
-            query: `
-                {
-                    streams(ids: [${streamIds.map((s) => `"${s}"`).join(',')}]) {
-                        items {
-                          id
-                          description
-                          peerCount
-                          messagesPerSecond
-                          subscriberCount
-                          publisherCount
-                        }
-                    }
-                }
-            `,
-        },
-    })
-
-    return result.data.streams.items
 }
 
 export const getStreamsOwnedBy = async (


### PR DESCRIPTION
The aim here is to be smarter about what gets loaded and who triggers the loading. In short,

- `QueriedStreamsTable` no longer takes `onBatch` and `statsQuery` – I've eliminated the dependency between the stats query and the streams query.
- `QueriedStreamsTable` component loads stats on its own, per page, and only when auxiliary stats are needed (they aren't if streams come from the indexer).
- I've done some dead/repeated code shake-off.

Onwards!