### PR TITLE
FRONT-1763: Prevent extra long stream names from pushing the "return" icon away

### DIFF
--- a/src/components/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem.tsx
@@ -139,6 +139,7 @@ const ItemRoot = styled.button<{ $highlight?: boolean; $highlightOnFocus?: boole
 
     > div:first-child {
         flex-grow: 1;
+        min-width: 0;
     }
 
     &[disabled] {

--- a/src/components/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem.tsx
@@ -122,6 +122,7 @@ const ItemRoot = styled.button<{ $highlight?: boolean; $highlightOnFocus?: boole
     background: none;
     border: 0;
     display: flex;
+    gap: 8px;
     font-size: 14px;
     line-height: 1.5;
     padding: 8px 24px;

--- a/src/components/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem.tsx
@@ -55,7 +55,7 @@ export function DropdownMenuItem({
                 }}
             >
                 <div>{children}</div>
-                <div>
+                <ReturnIconWrap>
                     <svg
                         width="20"
                         height="20"
@@ -84,7 +84,7 @@ export function DropdownMenuItem({
                             fill="black"
                         />
                     </svg>
-                </div>
+                </ReturnIconWrap>
             </ItemRoot>
         </li>
     )
@@ -105,6 +105,16 @@ function withPrevButton(el: HTMLElement, fn: (button: HTMLButtonElement | null) 
         ) as HTMLButtonElement | null,
     )
 }
+
+const ReturnIconWrap = styled.div`
+    opacity: 0;
+    transition: 100ms opacity;
+
+    > svg {
+        display: block;
+        border-radius: 4px;
+    }
+`
 
 const ItemRoot = styled.button<{ $highlight?: boolean; $highlightOnFocus?: boolean }>`
     align-items: center;
@@ -130,24 +140,14 @@ const ItemRoot = styled.button<{ $highlight?: boolean; $highlightOnFocus?: boole
         flex-grow: 1;
     }
 
-    > div:last-child {
-        opacity: 0;
-        transition: 100ms opacity;
-    }
-
     &[disabled] {
         background: none;
-    }
-
-    svg {
-        display: block;
-        border-radius: 4px;
     }
 
     ${({ $highlightOnFocus = false }) =>
         $highlightOnFocus &&
         css`
-            :focus > div:last-child {
+            :focus > ${ReturnIconWrap} {
                 opacity: 1;
             }
         `}
@@ -155,7 +155,7 @@ const ItemRoot = styled.button<{ $highlight?: boolean; $highlightOnFocus?: boole
     ${({ $highlight = false }) =>
         $highlight &&
         css`
-            > div:last-child {
+            > ${ReturnIconWrap} {
                 opacity: 1;
             }
         `}

--- a/src/components/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem.tsx
@@ -140,6 +140,8 @@ const ItemRoot = styled.button<{ $highlight?: boolean; $highlightOnFocus?: boole
     > div:first-child {
         flex-grow: 1;
         min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     &[disabled] {


### PR DESCRIPTION
The new approach is to make the dropdown content to never go beyond the available space and nicely trim it if it would.

![image](https://github.com/user-attachments/assets/1c5b6bc7-6440-4187-aa12-1bb64594909f)
