### PR TITLE
Remove `path-to-regexp`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
                 "moment-timezone": "^0.5.44",
                 "network-contracts-ethers6": "^7.1.1",
                 "normalizr": "^3.6.2",
-                "path-to-regexp": "^6.2.1",
                 "platform": "^1.3.6",
                 "prop-types": "^15.8.1",
                 "prosemirror-model": "^1.19.0",
@@ -41261,11 +41260,6 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
         },
         "node_modules/path-type": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
         "moment-timezone": "^0.5.44",
         "network-contracts-ethers6": "^7.1.1",
         "normalizr": "^3.6.2",
-        "path-to-regexp": "^6.2.1",
         "platform": "^1.3.6",
         "prop-types": "^15.8.1",
         "prosemirror-model": "^1.19.0",


### PR DESCRIPTION
Previous route utility used this package but it's no longer the case.