### PR TITLE
FRONT-1925: Fix auto-adding networks in the preflight

### DIFF
--- a/src/utils/networkPreflight.ts
+++ b/src/utils/networkPreflight.ts
@@ -48,6 +48,9 @@ export default async function networkPreflight(expectedChainId: number) {
                     chainName: chainConfig.name,
                     rpcUrls: chainConfig.rpcEndpoints.map(({ url }) => url),
                     nativeCurrency: chainConfig.nativeCurrency,
+                    blockExplorerUrls: [chainConfig.blockExplorerUrl].filter(
+                        Boolean,
+                    ) as string[],
                 },
             ],
         })


### PR DESCRIPTION
`blockExplorerUrls` has to be an array of strings.